### PR TITLE
Upgrade xmtp-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10945,9 +10945,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.26.0.tgz",
-      "integrity": "sha512-Xhvirf3yZlgaBo1nLQyVg9LQhwiVjg8S7wunf+RfP2Mrudx5bk1gS+9nx9ePcLcUSFfse0CwamqcTf6doxXNMg==",
+      "version": "3.28.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.28.0-beta.1.tgz",
+      "integrity": "sha512-gbDQ1FXKZe0j9RZxBK0Ohyy8C4z5I+ko58xmHk+QGO4QYb+cGsJyDSe0Re3oUa1tlnNudV0fkTR4nxcq4D+oIw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -10960,12 +10960,12 @@
       "link": true
     },
     "node_modules/@xmtp/xmtp-js": {
-      "version": "9.3.0-snap.1",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-9.3.0-snap.1.tgz",
-      "integrity": "sha512-RIc6nDK8vfj4w/BYfn9cXR4yUYSN0tSnKNL/CQ6wLdDNW4eYGl/Y3Gian+HbmyvBNroNaCh484HgkL3cLm07iQ==",
+      "version": "11.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-11.0.0-beta.7.tgz",
+      "integrity": "sha512-YpnsuVU7xx+J/KoWbZlApnfIM3dCwwfGB0YJ8/kssvltUxsdXMJym/xh8CheiOn9NWeBbs6NxX2H7vTU0wX5+w==",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@xmtp/proto": "^3.26.0",
+        "@xmtp/proto": "^3.28.0-beta.1",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
@@ -35044,8 +35044,8 @@
       "license": "(MIT-0 OR Apache-2.0)",
       "dependencies": {
         "@metamask/providers": "^9.0.0",
-        "@xmtp/proto": "^3.26.0",
-        "@xmtp/xmtp-js": "9.3.0-snap.1",
+        "@xmtp/proto": "^3.28.0-beta.1",
+        "@xmtp/xmtp-js": "^11.0.0-beta.7",
         "buffer": "^6.0.3",
         "ethers": "^6.6.2",
         "react": "^18.2.0",
@@ -35105,8 +35105,8 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@xmtp/proto": "^3.26.0",
-        "@xmtp/xmtp-js": "9.3.0-snap.1",
+        "@xmtp/proto": "^3.28.0-beta.1",
+        "@xmtp/xmtp-js": "^11.0.0-beta.7",
         "async-mutex": "^0.4.0",
         "buffer": "^6.0.3",
         "protobufjs": "^7.2.4"

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@metamask/providers": "^9.0.0",
-    "@xmtp/proto": "^3.26.0",
-    "@xmtp/xmtp-js": "9.3.0-snap.1",
+    "@xmtp/proto": "^3.28.0-beta.1",
+    "@xmtp/xmtp-js": "^11.0.0-beta.7",
     "buffer": "^6.0.3",
     "ethers": "^6.6.2",
     "react": "^18.2.0",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -38,8 +38,8 @@
     ]
   },
   "dependencies": {
-    "@xmtp/proto": "^3.26.0",
-    "@xmtp/xmtp-js": "9.3.0-snap.1",
+    "@xmtp/proto": "^3.28.0-beta.1",
+    "@xmtp/xmtp-js": "^11.0.0-beta.7",
     "async-mutex": "^0.4.0",
     "buffer": "^6.0.3",
     "protobufjs": "^7.2.4"

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/xmtp/snap.git"
   },
   "source": {
-    "shasum": "b5JxstM+SUDmu8WPTXRfDaXA5QZx9BNW2fQX/GC17/g=",
+    "shasum": "mBnXwLylK6madz+uBk4DIMjHM8Yg1ygRNcz6PMyzLMc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/handlers.ts
+++ b/packages/snap/src/handlers.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import {
   InMemoryKeystore,
+  Keystore,
   PrivateKeyBundleV1,
   keystoreApiDefs,
 } from '@xmtp/xmtp-js';
@@ -161,13 +162,16 @@ export function KeystoreHandler(backingKeystore: InMemoryKeystore) {
       throw new Error('no method found in keystore');
     }
 
+    // eslint-disable-next-line no-loop-func
     out[method] = async (req: SnapRequest): Promise<SnapResponse> => {
+      const backingMethod = backingKeystore[method as keyof Keystore];
+      if (typeof backingMethod !== 'function') {
+        throw new Error('not a function');
+      }
       return processProtoRequest(
         apiDef,
         req,
-        backingKeystore[method as keyof InMemoryKeystore].bind(
-          backingKeystore,
-        ) as any,
+        backingMethod.bind(backingKeystore) as any,
       );
     };
   }


### PR DESCRIPTION
## Summary

Uses more up-to-date beta version of `xmtp-js`, with the latest request/response types for the Keystore API