### PR TITLE
fix: update manifest version

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "1.2.2",
   "description": "A Snap that securely stores your XMTP keys across apps",
   "proposedName": "Sign in with XMTP",
   "repository": {


### PR DESCRIPTION
## Summary

I noticed that the version in the manifest doesn't match what's published to NPM. This reconciles the two. I have no idea if it matters (everything works in Flask), but it can't hurt to have them line up. I caught a line in the support request form that said they were allow-listing based on the manifest version and not the NPM version.

If it actually matters post-launch we'll have to automate the updating as part of the build process.