### PR TITLE
Ensure provenance is used when publishing

### DIFF
--- a/.changeset/slimy-peaches-share.md
+++ b/.changeset/slimy-peaches-share.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/snap": patch
+---
+
+Ensure provenance is used when publishing

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+provenance=true

--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
   "packageManager": "yarn@4.1.0",
   "engines": {
     "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
the previous publish did not include provenance. in an attempt to ensure the provenance option is respected during publish, this PR includes the following changes:

- added `publishConfig` to root `package.json`
- added `.npmrc` config file with `provenance=true`

not in this PR, i've also set the `NPM_CONFIG_PROVENANCE` environment variable to `true` for GitHub actions.