### PR TITLE
Add provenance when publishing (new strategy)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-provenance=true

--- a/.yarn/patches/@changesets-cli-npm-2.27.1-2cfd25f1c6.patch
+++ b/.yarn/patches/@changesets-cli-npm-2.27.1-2cfd25f1c6.patch
@@ -1,0 +1,4886 @@
+diff --git a/dist/changesets-cli.cjs.js b/dist/changesets-cli.cjs.js
+index 02083f394e874d25ca5ec9e7faaab83fe06e3761..de09c40e5cdcbb7eb74590bf2d3c1cfc8ceca90f 100644
+--- a/dist/changesets-cli.cjs.js
++++ b/dist/changesets-cli.cjs.js
+@@ -1,51 +1,61 @@
+-'use strict';
+-
+-var meow = require('meow');
+-var errors = require('@changesets/errors');
+-var logger = require('@changesets/logger');
+-var util = require('util');
+-var fs = require('fs-extra');
+-var path = require('path');
+-var getPackages = require('@manypkg/get-packages');
+-var getDependentsGraph = require('@changesets/get-dependents-graph');
+-var config = require('@changesets/config');
+-var _objectSpread = require('@babel/runtime/helpers/objectSpread2');
+-var chalk = require('chalk');
+-var child_process = require('child_process');
+-var termSize = require('term-size');
+-var enquirer = require('enquirer');
+-var externalEditor = require('external-editor');
+-var ansiColors = require('ansi-colors');
+-var git = require('@changesets/git');
+-var writeChangeset = require('@changesets/write');
+-var resolveFrom = require('resolve-from');
+-var semverLt = require('semver/functions/lt');
+-var outdent = require('outdent');
+-var applyReleasePlan = require('@changesets/apply-release-plan');
+-var readChangesets = require('@changesets/read');
+-var assembleReleasePlan = require('@changesets/assemble-release-plan');
+-var pre$1 = require('@changesets/pre');
+-var semverParse = require('semver/functions/parse');
+-var pLimit = require('p-limit');
+-var preferredPM = require('preferred-pm');
+-var spawn = require('spawndamnit');
+-var ciInfo = require('ci-info');
+-var table = require('tty-table');
+-var getReleasePlan = require('@changesets/get-release-plan');
+-
+-function _interopDefault (e) { return e && e.__esModule ? e : { 'default': e }; }
++"use strict";
++
++var meow = require("meow");
++var errors = require("@changesets/errors");
++var logger = require("@changesets/logger");
++var util = require("util");
++var fs = require("fs-extra");
++var path = require("path");
++var getPackages = require("@manypkg/get-packages");
++var getDependentsGraph = require("@changesets/get-dependents-graph");
++var config = require("@changesets/config");
++var _objectSpread = require("@babel/runtime/helpers/objectSpread2");
++var chalk = require("chalk");
++var child_process = require("child_process");
++var termSize = require("term-size");
++var enquirer = require("enquirer");
++var externalEditor = require("external-editor");
++var ansiColors = require("ansi-colors");
++var git = require("@changesets/git");
++var writeChangeset = require("@changesets/write");
++var resolveFrom = require("resolve-from");
++var semverLt = require("semver/functions/lt");
++var outdent = require("outdent");
++var applyReleasePlan = require("@changesets/apply-release-plan");
++var readChangesets = require("@changesets/read");
++var assembleReleasePlan = require("@changesets/assemble-release-plan");
++var pre$1 = require("@changesets/pre");
++var semverParse = require("semver/functions/parse");
++var pLimit = require("p-limit");
++var preferredPM = require("preferred-pm");
++var spawn = require("spawndamnit");
++var ciInfo = require("ci-info");
++var table = require("tty-table");
++var getReleasePlan = require("@changesets/get-release-plan");
++
++function _interopDefault(e) {
++  return e && e.__esModule ? e : { default: e };
++}
+ 
+ function _interopNamespace(e) {
+   if (e && e.__esModule) return e;
+   var n = Object.create(null);
+   if (e) {
+     Object.keys(e).forEach(function (k) {
+-      if (k !== 'default') {
++      if (k !== "default") {
+         var d = Object.getOwnPropertyDescriptor(e, k);
+-        Object.defineProperty(n, k, d.get ? d : {
+-          enumerable: true,
+-          get: function () { return e[k]; }
+-        });
++        Object.defineProperty(
++          n,
++          k,
++          d.get
++            ? d
++            : {
++                enumerable: true,
++                get: function () {
++                  return e[k];
++                },
++              }
++        );
+       }
+     });
+   }
+@@ -53,60 +63,114 @@ function _interopNamespace(e) {
+   return Object.freeze(n);
+ }
+ 
+-var meow__default = /*#__PURE__*/_interopDefault(meow);
+-var logger__namespace = /*#__PURE__*/_interopNamespace(logger);
+-var fs__default = /*#__PURE__*/_interopDefault(fs);
+-var path__default = /*#__PURE__*/_interopDefault(path);
+-var chalk__default = /*#__PURE__*/_interopDefault(chalk);
+-var termSize__default = /*#__PURE__*/_interopDefault(termSize);
+-var git__namespace = /*#__PURE__*/_interopNamespace(git);
+-var writeChangeset__default = /*#__PURE__*/_interopDefault(writeChangeset);
+-var resolveFrom__default = /*#__PURE__*/_interopDefault(resolveFrom);
+-var semverLt__default = /*#__PURE__*/_interopDefault(semverLt);
+-var outdent__default = /*#__PURE__*/_interopDefault(outdent);
+-var applyReleasePlan__default = /*#__PURE__*/_interopDefault(applyReleasePlan);
+-var readChangesets__default = /*#__PURE__*/_interopDefault(readChangesets);
+-var assembleReleasePlan__default = /*#__PURE__*/_interopDefault(assembleReleasePlan);
+-var semverParse__default = /*#__PURE__*/_interopDefault(semverParse);
+-var pLimit__default = /*#__PURE__*/_interopDefault(pLimit);
+-var preferredPM__default = /*#__PURE__*/_interopDefault(preferredPM);
+-var spawn__default = /*#__PURE__*/_interopDefault(spawn);
+-var table__default = /*#__PURE__*/_interopDefault(table);
+-var getReleasePlan__default = /*#__PURE__*/_interopDefault(getReleasePlan);
+-
+-const pkgPath = path__default["default"].dirname(require.resolve("@changesets/cli/package.json")); // Modify base branch to "main" without changing defaultWrittenConfig since it also serves as a fallback
++var meow__default = /*#__PURE__*/ _interopDefault(meow);
++var logger__namespace = /*#__PURE__*/ _interopNamespace(logger);
++var fs__default = /*#__PURE__*/ _interopDefault(fs);
++var path__default = /*#__PURE__*/ _interopDefault(path);
++var chalk__default = /*#__PURE__*/ _interopDefault(chalk);
++var termSize__default = /*#__PURE__*/ _interopDefault(termSize);
++var git__namespace = /*#__PURE__*/ _interopNamespace(git);
++var writeChangeset__default = /*#__PURE__*/ _interopDefault(writeChangeset);
++var resolveFrom__default = /*#__PURE__*/ _interopDefault(resolveFrom);
++var semverLt__default = /*#__PURE__*/ _interopDefault(semverLt);
++var outdent__default = /*#__PURE__*/ _interopDefault(outdent);
++var applyReleasePlan__default = /*#__PURE__*/ _interopDefault(applyReleasePlan);
++var readChangesets__default = /*#__PURE__*/ _interopDefault(readChangesets);
++var assembleReleasePlan__default =
++  /*#__PURE__*/ _interopDefault(assembleReleasePlan);
++var semverParse__default = /*#__PURE__*/ _interopDefault(semverParse);
++var pLimit__default = /*#__PURE__*/ _interopDefault(pLimit);
++var preferredPM__default = /*#__PURE__*/ _interopDefault(preferredPM);
++var spawn__default = /*#__PURE__*/ _interopDefault(spawn);
++var table__default = /*#__PURE__*/ _interopDefault(table);
++var getReleasePlan__default = /*#__PURE__*/ _interopDefault(getReleasePlan);
++
++const pkgPath = path__default["default"].dirname(
++  require.resolve("@changesets/cli/package.json")
++); // Modify base branch to "main" without changing defaultWrittenConfig since it also serves as a fallback
+ // for config files that don't specify a base branch. Changing that to main would be a breaking change.
+ 
+-const defaultConfig = `${JSON.stringify(_objectSpread(_objectSpread({}, config.defaultWrittenConfig), {}, {
+-  baseBranch: "main"
+-}), null, 2)}\n`;
++const defaultConfig = `${JSON.stringify(
++  _objectSpread(
++    _objectSpread({}, config.defaultWrittenConfig),
++    {},
++    {
++      baseBranch: "main",
++    }
++  ),
++  null,
++  2
++)}\n`;
+ async function init(cwd) {
+   const changesetBase = path__default["default"].resolve(cwd, ".changeset");
+ 
+   if (fs__default["default"].existsSync(changesetBase)) {
+-    if (!fs__default["default"].existsSync(path__default["default"].join(changesetBase, "config.json"))) {
+-      if (fs__default["default"].existsSync(path__default["default"].join(changesetBase, "config.js"))) {
+-        logger.error("It looks like you're using the version 1 `.changeset/config.js` file");
+-        logger.error("The format of the config object has significantly changed in v2 as well");
+-        logger.error(" - we thoroughly recommend looking at the changelog for this package for what has changed");
+-        logger.error("Changesets will write the defaults for the new config, remember to transfer your options into the new config at `.changeset/config.json`");
++    if (
++      !fs__default["default"].existsSync(
++        path__default["default"].join(changesetBase, "config.json")
++      )
++    ) {
++      if (
++        fs__default["default"].existsSync(
++          path__default["default"].join(changesetBase, "config.js")
++        )
++      ) {
++        logger.error(
++          "It looks like you're using the version 1 `.changeset/config.js` file"
++        );
++        logger.error(
++          "The format of the config object has significantly changed in v2 as well"
++        );
++        logger.error(
++          " - we thoroughly recommend looking at the changelog for this package for what has changed"
++        );
++        logger.error(
++          "Changesets will write the defaults for the new config, remember to transfer your options into the new config at `.changeset/config.json`"
++        );
+       } else {
+         logger.error("It looks like you don't have a config file");
+-        logger.info("The default config file will be written at `.changeset/config.json`");
++        logger.info(
++          "The default config file will be written at `.changeset/config.json`"
++        );
+       }
+ 
+-      await fs__default["default"].writeFile(path__default["default"].resolve(changesetBase, "config.json"), defaultConfig);
++      await fs__default["default"].writeFile(
++        path__default["default"].resolve(changesetBase, "config.json"),
++        defaultConfig
++      );
+     } else {
+-      logger.warn("It looks like you already have changesets initialized. You should be able to run changeset commands no problems.");
++      logger.warn(
++        "It looks like you already have changesets initialized. You should be able to run changeset commands no problems."
++      );
+     }
+   } else {
+-    await fs__default["default"].copy(path__default["default"].resolve(pkgPath, "./default-files"), changesetBase);
+-    await fs__default["default"].writeFile(path__default["default"].resolve(changesetBase, "config.json"), defaultConfig);
+-    logger.log(chalk__default["default"]`Thanks for choosing {green changesets} to help manage your versioning and publishing\n`);
++    await fs__default["default"].copy(
++      path__default["default"].resolve(pkgPath, "./default-files"),
++      changesetBase
++    );
++    await fs__default["default"].writeFile(
++      path__default["default"].resolve(changesetBase, "config.json"),
++      defaultConfig
++    );
++    logger.log(
++      chalk__default[
++        "default"
++      ]`Thanks for choosing {green changesets} to help manage your versioning and publishing\n`
++    );
+     logger.log("You should be set up to start using changesets now!\n");
+-    logger.info("We have added a `.changeset` folder, and a couple of files to help you out:");
+-    logger.info(chalk__default["default"]`- {blue .changeset/README.md} contains information about using changesets`);
+-    logger.info(chalk__default["default"]`- {blue .changeset/config.json} is our default config`);
++    logger.info(
++      "We have added a `.changeset` folder, and a couple of files to help you out:"
++    );
++    logger.info(
++      chalk__default[
++        "default"
++      ]`- {blue .changeset/README.md} contains information about using changesets`
++    );
++    logger.info(
++      chalk__default[
++        "default"
++      ]`- {blue .changeset/config.json} is our default config`
++    );
+   }
+ }
+ 
+@@ -118,10 +182,10 @@ async function init(cwd) {
+  * At each call, the entire responses object is returned, so we need a unique
+  * identifier for the name every time. This is why we are using serial IDs
+  */
+-const serialId = function () {
++const serialId = (function () {
+   let id = 0;
+   return () => id++;
+-}();
++})();
+ 
+ const limit = Math.max(termSize__default["default"]().rows - 5, 10);
+ 
+@@ -132,76 +196,96 @@ let cancelFlow = () => {
+ 
+ async function askCheckboxPlus(message, choices, format) {
+   const name = `CheckboxPlus-${serialId()}`;
+-  return enquirer.prompt({
+-    type: "autocomplete",
+-    name,
+-    message,
+-    prefix: logger.prefix,
+-    multiple: true,
+-    choices,
+-    format,
+-    limit,
+-    onCancel: cancelFlow,
+-    symbols: {
+-      indicator: ansiColors.symbols.radioOff,
+-      checked: ansiColors.symbols.radioOn
+-    },
+-
+-    indicator(state, choice) {
+-      return choice.enabled ? state.symbols.checked : state.symbols.indicator;
+-    }
+-
+-  }).then(responses => responses[name]).catch(err => {
+-    logger.error(err);
+-  });
++  return enquirer
++    .prompt({
++      type: "autocomplete",
++      name,
++      message,
++      prefix: logger.prefix,
++      multiple: true,
++      choices,
++      format,
++      limit,
++      onCancel: cancelFlow,
++      symbols: {
++        indicator: ansiColors.symbols.radioOff,
++        checked: ansiColors.symbols.radioOn,
++      },
++
++      indicator(state, choice) {
++        return choice.enabled ? state.symbols.checked : state.symbols.indicator;
++      },
++    })
++    .then((responses) => responses[name])
++    .catch((err) => {
++      logger.error(err);
++    });
+ }
+ 
+ async function askQuestion(message) {
+   const name = `Question-${serialId()}`;
+-  return enquirer.prompt([{
+-    type: "input",
+-    message,
+-    name,
+-    prefix: logger.prefix,
+-    onCancel: cancelFlow
+-  }]).then(responses => responses[name]).catch(err => {
+-    logger.error(err);
+-  });
++  return enquirer
++    .prompt([
++      {
++        type: "input",
++        message,
++        name,
++        prefix: logger.prefix,
++        onCancel: cancelFlow,
++      },
++    ])
++    .then((responses) => responses[name])
++    .catch((err) => {
++      logger.error(err);
++    });
+ }
+ 
+ function askQuestionWithEditor(message) {
+   const response = externalEditor.edit(message, {
+-    postfix: ".md"
++    postfix: ".md",
+   });
+-  return response.replace(/^#.*\n?/gm, "").replace(/\n+$/g, "").trim();
++  return response
++    .replace(/^#.*\n?/gm, "")
++    .replace(/\n+$/g, "")
++    .trim();
+ }
+ 
+ async function askConfirm(message) {
+   const name = `Confirm-${serialId()}`;
+-  return enquirer.prompt([{
+-    message,
+-    name,
+-    prefix: logger.prefix,
+-    type: "confirm",
+-    initial: true,
+-    onCancel: cancelFlow
+-  }]).then(responses => responses[name]).catch(err => {
+-    logger.error(err);
+-  });
++  return enquirer
++    .prompt([
++      {
++        message,
++        name,
++        prefix: logger.prefix,
++        type: "confirm",
++        initial: true,
++        onCancel: cancelFlow,
++      },
++    ])
++    .then((responses) => responses[name])
++    .catch((err) => {
++      logger.error(err);
++    });
+ }
+ 
+ async function askList(message, choices) {
+   const name = `List-${serialId()}`;
+-  return enquirer.prompt([{
+-    choices,
+-    message,
+-    name,
+-    prefix: logger.prefix,
+-    type: "select",
+-    onCancel: cancelFlow
+-  }]).then(responses => responses[name]).catch(err => {
+-    logger.error(err);
+-  });
++  return enquirer
++    .prompt([
++      {
++        choices,
++        message,
++        name,
++        prefix: logger.prefix,
++        type: "select",
++        onCancel: cancelFlow,
++      },
++    ])
++    .then((responses) => responses[name])
++    .catch((err) => {
++      logger.error(err);
++    });
+ }
+ 
+ function getCommitFunctions(commit, cwd) {
+@@ -221,7 +305,10 @@ function getCommitFunctions(commit, cwd) {
+     possibleCommitFunc = possibleCommitFunc.default;
+   }
+ 
+-  if (typeof possibleCommitFunc.getAddMessage === "function" || typeof possibleCommitFunc.getVersionMessage === "function") {
++  if (
++    typeof possibleCommitFunc.getAddMessage === "function" ||
++    typeof possibleCommitFunc.getVersionMessage === "function"
++  ) {
+     commitFunctions = possibleCommitFunc;
+   } else {
+     throw new Error("Could not resolve commit generation functions");
+@@ -230,21 +317,26 @@ function getCommitFunctions(commit, cwd) {
+   return [commitFunctions, commitOpts];
+ }
+ 
+-const {
+-  green,
+-  yellow,
+-  red,
+-  bold,
+-  blue,
+-  cyan
+-} = chalk__default["default"];
++const { green, yellow, red, bold, blue, cyan } = chalk__default["default"];
+ 
+ async function confirmMajorRelease(pkgJSON) {
+   if (semverLt__default["default"](pkgJSON.version, "1.0.0")) {
+     // prettier-ignore
+     logger.log(yellow(`WARNING: Releasing a major version for ${green(pkgJSON.name)} will be its ${red('first major release')}.`));
+-    logger.log(yellow(`If you are unsure if this is correct, contact the package's maintainers ${red("before committing this changeset")}.`));
+-    let shouldReleaseFirstMajor = await askConfirm(bold(`Are you sure you want to release the ${red("first major version")} of ${pkgJSON.name}?`));
++    logger.log(
++      yellow(
++        `If you are unsure if this is correct, contact the package's maintainers ${red(
++          "before committing this changeset"
++        )}.`
++      )
++    );
++    let shouldReleaseFirstMajor = await askConfirm(
++      bold(
++        `Are you sure you want to release the ${red(
++          "first major version"
++        )} of ${pkgJSON.name}?`
++      )
++    );
+     return shouldReleaseFirstMajor;
+   }
+ 
+@@ -253,32 +345,42 @@ async function confirmMajorRelease(pkgJSON) {
+ 
+ async function getPackagesToRelease(changedPackages, allPackages) {
+   function askInitialReleaseQuestion(defaultChoiceList) {
+-    return askCheckboxPlus( // TODO: Make this wording better
+-    // TODO: take objects and be fancy with matching
+-    `Which packages would you like to include?`, defaultChoiceList, x => {
+-      // this removes changed packages and unchanged packages from the list
+-      // of packages shown after selection
+-      if (Array.isArray(x)) {
+-        return x.filter(x => x !== "changed packages" && x !== "unchanged packages").map(x => cyan(x)).join(", ");
+-      }
++    return askCheckboxPlus(
++      // TODO: Make this wording better
++      // TODO: take objects and be fancy with matching
++      `Which packages would you like to include?`,
++      defaultChoiceList,
++      (x) => {
++        // this removes changed packages and unchanged packages from the list
++        // of packages shown after selection
++        if (Array.isArray(x)) {
++          return x
++            .filter(
++              (x) => x !== "changed packages" && x !== "unchanged packages"
++            )
++            .map((x) => cyan(x))
++            .join(", ");
++        }
+ 
+-      return x;
+-    });
++        return x;
++      }
++    );
+   }
+ 
+   if (allPackages.length > 1) {
+-    const unchangedPackagesNames = allPackages.map(({
+-      packageJson
+-    }) => packageJson.name).filter(name => !changedPackages.includes(name));
+-    const defaultChoiceList = [{
+-      name: "changed packages",
+-      choices: changedPackages
+-    }, {
+-      name: "unchanged packages",
+-      choices: unchangedPackagesNames
+-    }].filter(({
+-      choices
+-    }) => choices.length !== 0);
++    const unchangedPackagesNames = allPackages
++      .map(({ packageJson }) => packageJson.name)
++      .filter((name) => !changedPackages.includes(name));
++    const defaultChoiceList = [
++      {
++        name: "changed packages",
++        choices: changedPackages,
++      },
++      {
++        name: "unchanged packages",
++        choices: unchangedPackagesNames,
++      },
++    ].filter(({ choices }) => choices.length !== 0);
+     let packagesToRelease = await askInitialReleaseQuestion(defaultChoiceList);
+ 
+     if (packagesToRelease.length === 0) {
+@@ -289,16 +391,19 @@ async function getPackagesToRelease(changedPackages, allPackages) {
+       } while (packagesToRelease.length === 0);
+     }
+ 
+-    return packagesToRelease.filter(pkgName => pkgName !== "changed packages" && pkgName !== "unchanged packages");
++    return packagesToRelease.filter(
++      (pkgName) =>
++        pkgName !== "changed packages" && pkgName !== "unchanged packages"
++    );
+   }
+ 
+   return [allPackages[0].packageJson.name];
+ }
+ 
+ function getPkgJsonsByName(packages) {
+-  return new Map(packages.map(({
+-    packageJson
+-  }) => [packageJson.name, packageJson]));
++  return new Map(
++    packages.map(({ packageJson }) => [packageJson.name, packageJson])
++  );
+ }
+ 
+ function formatPkgNameAndVersion(pkgName, version) {
+@@ -309,26 +414,43 @@ async function createChangeset(changedPackages, allPackages) {
+   const releases = [];
+ 
+   if (allPackages.length > 1) {
+-    const packagesToRelease = await getPackagesToRelease(changedPackages, allPackages);
++    const packagesToRelease = await getPackagesToRelease(
++      changedPackages,
++      allPackages
++    );
+     let pkgJsonsByName = getPkgJsonsByName(allPackages);
+     let pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
+-    let pkgsThatShouldBeMajorBumped = (await askCheckboxPlus(bold(`Which packages should have a ${red("major")} bump?`), [{
+-      name: "all packages",
+-      choices: packagesToRelease.map(pkgName => {
+-        return {
+-          name: pkgName,
+-          message: formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version)
+-        };
+-      })
+-    }], x => {
+-      // this removes changed packages and unchanged packages from the list
+-      // of packages shown after selection
+-      if (Array.isArray(x)) {
+-        return x.filter(x => x !== "all packages").map(x => cyan(x)).join(", ");
+-      }
++    let pkgsThatShouldBeMajorBumped = (
++      await askCheckboxPlus(
++        bold(`Which packages should have a ${red("major")} bump?`),
++        [
++          {
++            name: "all packages",
++            choices: packagesToRelease.map((pkgName) => {
++              return {
++                name: pkgName,
++                message: formatPkgNameAndVersion(
++                  pkgName,
++                  pkgJsonsByName.get(pkgName).version
++                ),
++              };
++            }),
++          },
++        ],
++        (x) => {
++          // this removes changed packages and unchanged packages from the list
++          // of packages shown after selection
++          if (Array.isArray(x)) {
++            return x
++              .filter((x) => x !== "all packages")
++              .map((x) => cyan(x))
++              .join(", ");
++          }
+ 
+-      return x;
+-    })).filter(x => x !== "all packages");
++          return x;
++        }
++      )
++    ).filter((x) => x !== "all packages");
+ 
+     for (const pkgName of pkgsThatShouldBeMajorBumped) {
+       // for packages that are under v1, we want to make sure major releases are intended,
+@@ -341,55 +463,76 @@ async function createChangeset(changedPackages, allPackages) {
+         pkgsLeftToGetBumpTypeFor.delete(pkgName);
+         releases.push({
+           name: pkgName,
+-          type: "major"
++          type: "major",
+         });
+       }
+     }
+ 
+     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
+-      let pkgsThatShouldBeMinorBumped = (await askCheckboxPlus(bold(`Which packages should have a ${green("minor")} bump?`), [{
+-        name: "all packages",
+-        choices: [...pkgsLeftToGetBumpTypeFor].map(pkgName => {
+-          return {
+-            name: pkgName,
+-            message: formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version)
+-          };
+-        })
+-      }], x => {
+-        // this removes changed packages and unchanged packages from the list
+-        // of packages shown after selection
+-        if (Array.isArray(x)) {
+-          return x.filter(x => x !== "all packages").map(x => cyan(x)).join(", ");
+-        }
++      let pkgsThatShouldBeMinorBumped = (
++        await askCheckboxPlus(
++          bold(`Which packages should have a ${green("minor")} bump?`),
++          [
++            {
++              name: "all packages",
++              choices: [...pkgsLeftToGetBumpTypeFor].map((pkgName) => {
++                return {
++                  name: pkgName,
++                  message: formatPkgNameAndVersion(
++                    pkgName,
++                    pkgJsonsByName.get(pkgName).version
++                  ),
++                };
++              }),
++            },
++          ],
++          (x) => {
++            // this removes changed packages and unchanged packages from the list
++            // of packages shown after selection
++            if (Array.isArray(x)) {
++              return x
++                .filter((x) => x !== "all packages")
++                .map((x) => cyan(x))
++                .join(", ");
++            }
+ 
+-        return x;
+-      })).filter(x => x !== "all packages");
++            return x;
++          }
++        )
++      ).filter((x) => x !== "all packages");
+ 
+       for (const pkgName of pkgsThatShouldBeMinorBumped) {
+         pkgsLeftToGetBumpTypeFor.delete(pkgName);
+         releases.push({
+           name: pkgName,
+-          type: "minor"
++          type: "minor",
+         });
+       }
+     }
+ 
+     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
+       logger.log(`The following packages will be ${blue("patch")} bumped:`);
+-      pkgsLeftToGetBumpTypeFor.forEach(pkgName => {
+-        logger.log(formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version));
++      pkgsLeftToGetBumpTypeFor.forEach((pkgName) => {
++        logger.log(
++          formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version)
++        );
+       });
+ 
+       for (const pkgName of pkgsLeftToGetBumpTypeFor) {
+         releases.push({
+           name: pkgName,
+-          type: "patch"
++          type: "patch",
+         });
+       }
+     }
+   } else {
+     let pkg = allPackages[0];
+-    let type = await askList(`What kind of change is this for ${green(pkg.packageJson.name)}? (current version is ${pkg.packageJson.version})`, ["patch", "minor", "major"]);
++    let type = await askList(
++      `What kind of change is this for ${green(
++        pkg.packageJson.name
++      )}? (current version is ${pkg.packageJson.version})`,
++      ["patch", "minor", "major"]
++    );
+ 
+     if (type === "major") {
+       let shouldReleaseAsMajor = await confirmMajorRelease(pkg.packageJson);
+@@ -401,61 +544,92 @@ async function createChangeset(changedPackages, allPackages) {
+ 
+     releases.push({
+       name: pkg.packageJson.name,
+-      type
++      type,
+     });
+   }
+ 
+-  logger.log("Please enter a summary for this change (this will be in the changelogs).");
+-  logger.log(chalk__default["default"].gray("  (submit empty line to open external editor)"));
++  logger.log(
++    "Please enter a summary for this change (this will be in the changelogs)."
++  );
++  logger.log(
++    chalk__default["default"].gray(
++      "  (submit empty line to open external editor)"
++    )
++  );
+   let summary = await askQuestion("Summary");
+ 
+   if (summary.length === 0) {
+     try {
+-      summary = askQuestionWithEditor("\n\n# Please enter a summary for your changes.\n# An empty message aborts the editor.");
++      summary = askQuestionWithEditor(
++        "\n\n# Please enter a summary for your changes.\n# An empty message aborts the editor."
++      );
+ 
+       if (summary.length > 0) {
+         return {
+           confirmed: true,
+           summary,
+-          releases
++          releases,
+         };
+       }
+     } catch (err) {
+-      logger.log("An error happened using external editor. Please type your summary here:");
++      logger.log(
++        "An error happened using external editor. Please type your summary here:"
++      );
+     }
+ 
+     summary = await askQuestion("");
+ 
+     while (summary.length === 0) {
+-      summary = await askQuestion("\n\n# A summary is required for the changelog! 😪");
++      summary = await askQuestion(
++        "\n\n# A summary is required for the changelog! 😪"
++      );
+     }
+   }
+ 
+   return {
+     confirmed: false,
+     summary,
+-    releases
++    releases,
+   };
+ }
+ 
+ function printConfirmationMessage(changeset, repoHasMultiplePackages) {
+   function getReleasesOfType(type) {
+-    return changeset.releases.filter(release => release.type === type).map(release => release.name);
++    return changeset.releases
++      .filter((release) => release.type === type)
++      .map((release) => release.name);
+   }
+ 
+   logger.log("\n=== Summary of changesets ===");
+   const majorReleases = getReleasesOfType("major");
+   const minorReleases = getReleasesOfType("minor");
+   const patchReleases = getReleasesOfType("patch");
+-  if (majorReleases.length > 0) logger.log(`${chalk__default["default"].bold.green("major")}:  ${majorReleases.join(", ")}`);
+-  if (minorReleases.length > 0) logger.log(`${chalk__default["default"].bold.green("minor")}:  ${minorReleases.join(", ")}`);
+-  if (patchReleases.length > 0) logger.log(`${chalk__default["default"].bold.green("patch")}:  ${patchReleases.join(", ")}`);
++  if (majorReleases.length > 0)
++    logger.log(
++      `${chalk__default["default"].bold.green("major")}:  ${majorReleases.join(
++        ", "
++      )}`
++    );
++  if (minorReleases.length > 0)
++    logger.log(
++      `${chalk__default["default"].bold.green("minor")}:  ${minorReleases.join(
++        ", "
++      )}`
++    );
++  if (patchReleases.length > 0)
++    logger.log(
++      `${chalk__default["default"].bold.green("patch")}:  ${patchReleases.join(
++        ", "
++      )}`
++    );
+   logger.log("");
+ 
+   if (repoHasMultiplePackages) {
+     const message = outdent__default["default"]`
+       Note: All dependents of these packages that will be incompatible with
+-      the new version will be ${chalk__default["default"].redBright("patch bumped")} when this changeset is applied.
++      the new version will be ${chalk__default["default"].redBright(
++        "patch bumped"
++      )} when this changeset is applied.
+     `;
+     logger.log(message + "\n");
+   }
+@@ -476,17 +650,18 @@ function isListablePackage(config, packageJson) {
+   return hasVersionField;
+ }
+ 
+-async function add(cwd, {
+-  empty,
+-  open
+-}, config) {
++async function add(cwd, { empty, open }, config) {
+   const packages = await getPackages.getPackages(cwd);
+ 
+   if (packages.packages.length === 0) {
+-    throw new Error(`No packages found. You might have ${packages.tool} workspaces configured but no packages yet?`);
++    throw new Error(
++      `No packages found. You might have ${packages.tool} workspaces configured but no packages yet?`
++    );
+   }
+ 
+-  const listablePackages = packages.packages.filter(pkg => isListablePackage(config, pkg.packageJson));
++  const listablePackages = packages.packages.filter((pkg) =>
++    isListablePackage(config, pkg.packageJson)
++  );
+   const changesetBase = path__default["default"].resolve(cwd, ".changeset");
+   let newChangeset;
+ 
+@@ -494,61 +669,100 @@ async function add(cwd, {
+     newChangeset = {
+       confirmed: true,
+       releases: [],
+-      summary: ``
++      summary: ``,
+     };
+   } else {
+     const changedPackages = await git__namespace.getChangedPackagesSinceRef({
+       cwd,
+       ref: config.baseBranch,
+-      changedFilePatterns: config.changedFilePatterns
++      changedFilePatterns: config.changedFilePatterns,
+     });
+-    const changedPackagesName = changedPackages.filter(pkg => isListablePackage(config, pkg.packageJson)).map(pkg => pkg.packageJson.name);
++    const changedPackagesName = changedPackages
++      .filter((pkg) => isListablePackage(config, pkg.packageJson))
++      .map((pkg) => pkg.packageJson.name);
+     newChangeset = await createChangeset(changedPackagesName, listablePackages);
+     printConfirmationMessage(newChangeset, listablePackages.length > 1);
+ 
+     if (!newChangeset.confirmed) {
+-      newChangeset = _objectSpread(_objectSpread({}, newChangeset), {}, {
+-        confirmed: await askConfirm("Is this your desired changeset?")
+-      });
++      newChangeset = _objectSpread(
++        _objectSpread({}, newChangeset),
++        {},
++        {
++          confirmed: await askConfirm("Is this your desired changeset?"),
++        }
++      );
+     }
+   }
+ 
+   if (newChangeset.confirmed) {
+-    const changesetID = await writeChangeset__default["default"](newChangeset, cwd);
+-    const [{
+-      getAddMessage
+-    }, commitOpts] = getCommitFunctions(config.commit, cwd);
++    const changesetID = await writeChangeset__default["default"](
++      newChangeset,
++      cwd
++    );
++    const [{ getAddMessage }, commitOpts] = getCommitFunctions(
++      config.commit,
++      cwd
++    );
+ 
+     if (getAddMessage) {
+-      await git__namespace.add(path__default["default"].resolve(changesetBase, `${changesetID}.md`), cwd);
+-      await git__namespace.commit(await getAddMessage(newChangeset, commitOpts), cwd);
+-      logger.log(chalk__default["default"].green(`${empty ? "Empty " : ""}Changeset added and committed`));
++      await git__namespace.add(
++        path__default["default"].resolve(changesetBase, `${changesetID}.md`),
++        cwd
++      );
++      await git__namespace.commit(
++        await getAddMessage(newChangeset, commitOpts),
++        cwd
++      );
++      logger.log(
++        chalk__default["default"].green(
++          `${empty ? "Empty " : ""}Changeset added and committed`
++        )
++      );
+     } else {
+-      logger.log(chalk__default["default"].green(`${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`));
++      logger.log(
++        chalk__default["default"].green(
++          `${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`
++        )
++      );
+     }
+ 
+-    let hasMajorChange = [...newChangeset.releases].find(c => c.type === "major");
++    let hasMajorChange = [...newChangeset.releases].find(
++      (c) => c.type === "major"
++    );
+ 
+     if (hasMajorChange) {
+-      logger.warn("This Changeset includes a major change and we STRONGLY recommend adding more information to the changeset:");
++      logger.warn(
++        "This Changeset includes a major change and we STRONGLY recommend adding more information to the changeset:"
++      );
+       logger.warn("WHAT the breaking change is");
+       logger.warn("WHY the change was made");
+       logger.warn("HOW a consumer should update their code");
+     } else {
+-      logger.log(chalk__default["default"].green("If you want to modify or expand on the changeset summary, you can find it here"));
++      logger.log(
++        chalk__default["default"].green(
++          "If you want to modify or expand on the changeset summary, you can find it here"
++        )
++      );
+     }
+ 
+-    const changesetPath = path__default["default"].resolve(changesetBase, `${changesetID}.md`);
++    const changesetPath = path__default["default"].resolve(
++      changesetBase,
++      `${changesetID}.md`
++    );
+     logger.info(chalk__default["default"].blue(changesetPath));
+ 
+     if (open) {
+       // this is really a hack to reuse the logic embedded in `external-editor` related to determining the editor
+       const externalEditor$1 = new externalEditor.ExternalEditor();
+       externalEditor$1.cleanup();
+-      child_process.spawn(externalEditor$1.editor.bin, externalEditor$1.editor.args.concat([changesetPath]), {
+-        detached: true,
+-        stdio: "inherit"
+-      });
++      child_process.spawn(
++        externalEditor$1.editor.bin,
++        externalEditor$1.editor.args.concat([changesetPath]),
++        {
++          detached: true,
++          stdio: "inherit",
++        }
++      );
+     }
+   }
+ }
+@@ -556,89 +770,150 @@ async function add(cwd, {
+ // folder, and tidy up the subfolders
+ // THIS SHOULD BE REMOVED WHEN SUPPORT FOR CHANGESETS FROM V1 IS DROPPED
+ 
+-const removeEmptyFolders = async folderPath => {
++const removeEmptyFolders = async (folderPath) => {
+   const dirContents = fs__default["default"].readdirSync(folderPath);
+-  return Promise.all(dirContents.map(async contentPath => {
+-    const singleChangesetPath = path__default["default"].resolve(folderPath, contentPath);
+-
+-    try {
+-      if ((await fs__default["default"].readdir(singleChangesetPath)).length < 1) {
+-        await fs__default["default"].rmdir(singleChangesetPath);
+-      }
+-    } catch (err) {
+-      if (err.code !== "ENOTDIR") {
+-        throw err;
++  return Promise.all(
++    dirContents.map(async (contentPath) => {
++      const singleChangesetPath = path__default["default"].resolve(
++        folderPath,
++        contentPath
++      );
++
++      try {
++        if (
++          (await fs__default["default"].readdir(singleChangesetPath)).length < 1
++        ) {
++          await fs__default["default"].rmdir(singleChangesetPath);
++        }
++      } catch (err) {
++        if (err.code !== "ENOTDIR") {
++          throw err;
++        }
+       }
+-    }
+-  }));
++    })
++  );
+ };
+ 
+-let importantSeparator$1 = chalk__default["default"].red("===============================IMPORTANT!===============================");
+-let importantEnd$1 = chalk__default["default"].red("----------------------------------------------------------------------");
++let importantSeparator$1 = chalk__default["default"].red(
++  "===============================IMPORTANT!==============================="
++);
++let importantEnd$1 = chalk__default["default"].red(
++  "----------------------------------------------------------------------"
++);
+ async function version(cwd, options, config) {
+   var _config$snapshot$prer;
+ 
+-  const releaseConfig = _objectSpread(_objectSpread({}, config), {}, {
+-    // Disable committing when in snapshot mode
+-    commit: options.snapshot ? false : config.commit
+-  });
+-
+-  const [changesets, preState] = await Promise.all([readChangesets__default["default"](cwd), pre$1.readPreState(cwd), removeEmptyFolders(path__default["default"].resolve(cwd, ".changeset"))]);
+-
+-  if ((preState === null || preState === void 0 ? void 0 : preState.mode) === "pre") {
++  const releaseConfig = _objectSpread(
++    _objectSpread({}, config),
++    {},
++    {
++      // Disable committing when in snapshot mode
++      commit: options.snapshot ? false : config.commit,
++    }
++  );
++
++  const [changesets, preState] = await Promise.all([
++    readChangesets__default["default"](cwd),
++    pre$1.readPreState(cwd),
++    removeEmptyFolders(path__default["default"].resolve(cwd, ".changeset")),
++  ]);
++
++  if (
++    (preState === null || preState === void 0 ? void 0 : preState.mode) ===
++    "pre"
++  ) {
+     logger.warn(importantSeparator$1);
+ 
+     if (options.snapshot !== undefined) {
+       logger.error("Snapshot release is not allowed in pre mode");
+-      logger.log("To resolve this exit the pre mode by running `changeset pre exit`");
++      logger.log(
++        "To resolve this exit the pre mode by running `changeset pre exit`"
++      );
+       throw new errors.ExitError(1);
+     } else {
+       logger.warn("You are in prerelease mode");
+-      logger.warn("If you meant to do a normal release you should revert these changes and run `changeset pre exit`");
+-      logger.warn("You can then run `changeset version` again to do a normal release");
++      logger.warn(
++        "If you meant to do a normal release you should revert these changes and run `changeset pre exit`"
++      );
++      logger.warn(
++        "You can then run `changeset version` again to do a normal release"
++      );
+     }
+ 
+     logger.warn(importantEnd$1);
+   }
+ 
+-  if (changesets.length === 0 && (preState === undefined || preState.mode !== "exit")) {
++  if (
++    changesets.length === 0 &&
++    (preState === undefined || preState.mode !== "exit")
++  ) {
+     logger.warn("No unreleased changesets found, exiting.");
+     return;
+   }
+ 
+   let packages = await getPackages.getPackages(cwd);
+-  let releasePlan = assembleReleasePlan__default["default"](changesets, packages, releaseConfig, preState, options.snapshot ? {
+-    tag: options.snapshot === true ? undefined : options.snapshot,
+-    commit: (_config$snapshot$prer = config.snapshot.prereleaseTemplate) !== null && _config$snapshot$prer !== void 0 && _config$snapshot$prer.includes("{commit}") ? await git.getCurrentCommitId({
+-      cwd
+-    }) : undefined
+-  } : undefined);
+-  let [...touchedFiles] = await applyReleasePlan__default["default"](releasePlan, packages, releaseConfig, options.snapshot);
+-  const [{
+-    getVersionMessage
+-  }, commitOpts] = getCommitFunctions(releaseConfig.commit, cwd);
++  let releasePlan = assembleReleasePlan__default["default"](
++    changesets,
++    packages,
++    releaseConfig,
++    preState,
++    options.snapshot
++      ? {
++          tag: options.snapshot === true ? undefined : options.snapshot,
++          commit:
++            (_config$snapshot$prer = config.snapshot.prereleaseTemplate) !==
++              null &&
++            _config$snapshot$prer !== void 0 &&
++            _config$snapshot$prer.includes("{commit}")
++              ? await git.getCurrentCommitId({
++                  cwd,
++                })
++              : undefined,
++        }
++      : undefined
++  );
++  let [...touchedFiles] = await applyReleasePlan__default["default"](
++    releasePlan,
++    packages,
++    releaseConfig,
++    options.snapshot
++  );
++  const [{ getVersionMessage }, commitOpts] = getCommitFunctions(
++    releaseConfig.commit,
++    cwd
++  );
+ 
+   if (getVersionMessage) {
+     let touchedFile; // Note, git gets angry if you try and have two git actions running at once
+     // So we need to be careful that these iterations are properly sequential
+ 
+-    while (touchedFile = touchedFiles.shift()) {
+-      await git__namespace.add(path__default["default"].relative(cwd, touchedFile), cwd);
++    while ((touchedFile = touchedFiles.shift())) {
++      await git__namespace.add(
++        path__default["default"].relative(cwd, touchedFile),
++        cwd
++      );
+     }
+ 
+-    const commit = await git__namespace.commit(await getVersionMessage(releasePlan, commitOpts), cwd);
++    const commit = await git__namespace.commit(
++      await getVersionMessage(releasePlan, commitOpts),
++      cwd
++    );
+ 
+     if (!commit) {
+       logger.error("Changesets ran into trouble committing your files");
+     } else {
+-      logger.log("All files have been updated and committed. You're ready to publish!");
++      logger.log(
++        "All files have been updated and committed. You're ready to publish!"
++      );
+     }
+   } else {
+-    logger.log("All files have been updated. Review them and commit at your leisure");
++    logger.log(
++      "All files have been updated. Review them and commit at your leisure"
++    );
+   }
+ }
+ 
+-const getLastJsonObjectFromString = str => {
++const getLastJsonObjectFromString = (str) => {
+   str = str.replace(/[^}]*$/, "");
+ 
+   while (str) {
+@@ -673,30 +948,47 @@ function jsonParse(input) {
+ function getCorrectRegistry(packageJson) {
+   var _packageJson$publishC, _packageJson$publishC2;
+ 
+-  const registry = (_packageJson$publishC = packageJson === null || packageJson === void 0 ? void 0 : (_packageJson$publishC2 = packageJson.publishConfig) === null || _packageJson$publishC2 === void 0 ? void 0 : _packageJson$publishC2.registry) !== null && _packageJson$publishC !== void 0 ? _packageJson$publishC : process.env.npm_config_registry;
+-  return !registry || registry === "https://registry.yarnpkg.com" ? "https://registry.npmjs.org" : registry;
++  const registry =
++    (_packageJson$publishC =
++      packageJson === null || packageJson === void 0
++        ? void 0
++        : (_packageJson$publishC2 = packageJson.publishConfig) === null ||
++          _packageJson$publishC2 === void 0
++        ? void 0
++        : _packageJson$publishC2.registry) !== null &&
++    _packageJson$publishC !== void 0
++      ? _packageJson$publishC
++      : process.env.npm_config_registry;
++  return !registry || registry === "https://registry.yarnpkg.com"
++    ? "https://registry.npmjs.org"
++    : registry;
+ }
+ 
+ async function getPublishTool(cwd) {
+   const pm = await preferredPM__default["default"](cwd);
+-  if (!pm || pm.name !== "pnpm") return {
+-    name: "npm"
+-  };
++  if (!pm || pm.name !== "pnpm")
++    return {
++      name: "npm",
++    };
+ 
+   try {
+     let result = await spawn__default["default"]("pnpm", ["--version"], {
+-      cwd
++      cwd,
+     });
+     let version = result.stdout.toString().trim();
+     let parsed = semverParse__default["default"](version);
+     return {
+       name: "pnpm",
+-      shouldAddNoGitChecks: (parsed === null || parsed === void 0 ? void 0 : parsed.major) === undefined ? false : parsed.major >= 5
++      shouldAddNoGitChecks:
++        (parsed === null || parsed === void 0 ? void 0 : parsed.major) ===
++        undefined
++          ? false
++          : parsed.major >= 5,
+     };
+   } catch (e) {
+     return {
+       name: "pnpm",
+-      shouldAddNoGitChecks: false
++      shouldAddNoGitChecks: false,
+     };
+   }
+ }
+@@ -705,14 +997,21 @@ async function getTokenIsRequired() {
+   // Due to a super annoying issue in yarn, we have to manually override this env variable
+   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+   const envOverride = {
+-    npm_config_registry: getCorrectRegistry()
++    npm_config_registry: getCorrectRegistry(),
+   };
+-  let result = await spawn__default["default"]("npm", ["profile", "get", "--json"], {
+-    env: Object.assign({}, process.env, envOverride)
+-  });
++  let result = await spawn__default["default"](
++    "npm",
++    ["profile", "get", "--json"],
++    {
++      env: Object.assign({}, process.env, envOverride),
++    }
++  );
+ 
+   if (result.code !== 0) {
+-    logger.error("error while checking if token is required", result.stderr.toString().trim() || result.stdout.toString().trim());
++    logger.error(
++      "error while checking if token is required",
++      result.stderr.toString().trim() || result.stdout.toString().trim()
++    );
+     return false;
+   }
+ 
+@@ -733,14 +1032,20 @@ function getPackageInfo(packageJson) {
+     // as they will always give a 404, which will tell `publish` to always try to publish.
+     // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+ 
+-    let result = await spawn__default["default"]("npm", ["info", packageJson.name, "--registry", getCorrectRegistry(packageJson), "--json"]); // Github package registry returns empty string when calling npm info
++    let result = await spawn__default["default"]("npm", [
++      "info",
++      packageJson.name,
++      "--registry",
++      getCorrectRegistry(packageJson),
++      "--json",
++    ]); // Github package registry returns empty string when calling npm info
+     // for a non-existent package instead of a E404
+ 
+     if (result.stdout.toString() === "") {
+       return {
+         error: {
+-          code: "E404"
+-        }
++          code: "E404",
++        },
+       };
+     }
+ 
+@@ -752,16 +1057,28 @@ async function infoAllow404(packageJson) {
+ 
+   let pkgInfo = await getPackageInfo(packageJson);
+ 
+-  if (((_pkgInfo$error = pkgInfo.error) === null || _pkgInfo$error === void 0 ? void 0 : _pkgInfo$error.code) === "E404") {
+-    logger.warn(`Received 404 for npm info ${chalk__default["default"].cyan(`"${packageJson.name}"`)}`);
++  if (
++    ((_pkgInfo$error = pkgInfo.error) === null || _pkgInfo$error === void 0
++      ? void 0
++      : _pkgInfo$error.code) === "E404"
++  ) {
++    logger.warn(
++      `Received 404 for npm info ${chalk__default["default"].cyan(
++        `"${packageJson.name}"`
++      )}`
++    );
+     return {
+       published: false,
+-      pkgInfo: {}
++      pkgInfo: {},
+     };
+   }
+ 
+   if (pkgInfo.error) {
+-    logger.error(`Received an unknown error code: ${pkgInfo.error.code} for npm info ${chalk__default["default"].cyan(`"${packageJson.name}"`)}`);
++    logger.error(
++      `Received an unknown error code: ${
++        pkgInfo.error.code
++      } for npm info ${chalk__default["default"].cyan(`"${packageJson.name}"`)}`
++    );
+     logger.error(pkgInfo.error.summary);
+     if (pkgInfo.error.detail) logger.error(pkgInfo.error.detail);
+     throw new errors.ExitError(1);
+@@ -769,20 +1086,23 @@ async function infoAllow404(packageJson) {
+ 
+   return {
+     published: true,
+-    pkgInfo
++    pkgInfo,
+   };
+ }
+ let otpAskLimit = pLimit__default["default"](1);
+ 
+-let askForOtpCode = twoFactorState => otpAskLimit(async () => {
+-  if (twoFactorState.token !== null) return twoFactorState.token;
+-  logger.info("This operation requires a one-time password from your authenticator.");
+-  let val = await askQuestion("Enter one-time password:");
+-  twoFactorState.token = val;
+-  return val;
+-});
++let askForOtpCode = (twoFactorState) =>
++  otpAskLimit(async () => {
++    if (twoFactorState.token !== null) return twoFactorState.token;
++    logger.info(
++      "This operation requires a one-time password from your authenticator."
++    );
++    let val = await askQuestion("Enter one-time password:");
++    twoFactorState.token = val;
++    return val;
++  });
+ 
+-let getOtpCode = async twoFactorState => {
++let getOtpCode = async (twoFactorState) => {
+   if (twoFactorState.token !== null) {
+     return twoFactorState.token;
+   }
+@@ -806,20 +1126,32 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+   } // Due to a super annoying issue in yarn, we have to manually override this env variable
+   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+ 
++  // add provenance flag when publishing with NPM
++  // @see https://github.com/changesets/changesets/issues/1152
++  if (publishTool.name === "npm") {
++    publishFlags.push("--provenance");
++  }
+ 
+   const envOverride = {
+-    npm_config_registry: getCorrectRegistry()
++    npm_config_registry: getCorrectRegistry(),
+   };
+-  let {
+-    code,
+-    stdout,
+-    stderr
+-  } = publishTool.name === "pnpm" ? await spawn__default["default"]("pnpm", ["publish", "--json", ...publishFlags], {
+-    env: Object.assign({}, process.env, envOverride),
+-    cwd: opts.cwd
+-  }) : await spawn__default["default"](publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
+-    env: Object.assign({}, process.env, envOverride)
+-  });
++  let { code, stdout, stderr } =
++    publishTool.name === "pnpm"
++      ? await spawn__default["default"](
++          "pnpm",
++          ["publish", "--json", ...publishFlags],
++          {
++            env: Object.assign({}, process.env, envOverride),
++            cwd: opts.cwd,
++          }
++        )
++      : await spawn__default["default"](
++          publishTool.name,
++          ["publish", opts.publishDir, "--json", ...publishFlags],
++          {
++            env: Object.assign({}, process.env, envOverride),
++          }
++        );
+ 
+   if (code !== 0) {
+     // NPM's --json output is included alongside the `prepublish` and `postpublish` output in terminal
+@@ -827,39 +1159,51 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+     // - output of those lifecycle scripts can contain JSON
+     // - npm7 has switched to printing `--json` errors to stderr (https://github.com/npm/cli/commit/1dbf0f9bb26ba70f4c6d0a807701d7652c31d7d4)
+     // Note that the `--json` output is always printed at the end so this should work
+-    let json = getLastJsonObjectFromString(stderr.toString()) || getLastJsonObjectFromString(stdout.toString());
++    let json =
++      getLastJsonObjectFromString(stderr.toString()) ||
++      getLastJsonObjectFromString(stdout.toString());
+ 
+     if (json !== null && json !== void 0 && json.error) {
+       // The first case is no 2fa provided, the second is when the 2fa is wrong (timeout or wrong words)
+-      if ((json.error.code === "EOTP" || json.error.code === "E401" && json.error.detail.includes("--otp=<code>")) && !ciInfo.isCI) {
++      if (
++        (json.error.code === "EOTP" ||
++          (json.error.code === "E401" &&
++            json.error.detail.includes("--otp=<code>"))) &&
++        !ciInfo.isCI
++      ) {
+         if (twoFactorState.token !== null) {
+           // the current otp code must be invalid since it errored
+           twoFactorState.token = null;
+         } // just in case this isn't already true
+ 
+-
+         twoFactorState.isRequired = Promise.resolve(true);
+         return internalPublish(pkgName, opts, twoFactorState);
+       }
+ 
+-      logger.error(`an error occurred while publishing ${pkgName}: ${json.error.code}`, json.error.summary, json.error.detail ? "\n" + json.error.detail : "");
++      logger.error(
++        `an error occurred while publishing ${pkgName}: ${json.error.code}`,
++        json.error.summary,
++        json.error.detail ? "\n" + json.error.detail : ""
++      );
+     }
+ 
+     logger.error(stderr.toString() || stdout.toString());
+     return {
+-      published: false
++      published: false,
+     };
+   }
+ 
+   return {
+-    published: true
++    published: true,
+   };
+ }
+ 
+ function publish(pkgName, opts, twoFactorState) {
+   // If there are many packages to be published, it's better to limit the
+   // concurrency to avoid unwanted errors, for example from npm.
+-  return npmRequestLimit(() => npmPublishLimit(() => internalPublish(pkgName, opts, twoFactorState)));
++  return npmRequestLimit(() =>
++    npmPublishLimit(() => internalPublish(pkgName, opts, twoFactorState))
++  );
+ }
+ 
+ function getReleaseTag(pkgInfo, preState, tag) {
+@@ -872,47 +1216,53 @@ function getReleaseTag(pkgInfo, preState, tag) {
+   return "latest";
+ }
+ 
+-const isCustomRegistry = registry => !!registry && registry !== "https://registry.npmjs.org" && registry !== "https://registry.yarnpkg.com";
++const isCustomRegistry = (registry) =>
++  !!registry &&
++  registry !== "https://registry.npmjs.org" &&
++  registry !== "https://registry.yarnpkg.com";
+ 
+-const getTwoFactorState = ({
+-  otp,
+-  publicPackages
+-}) => {
++const getTwoFactorState = ({ otp, publicPackages }) => {
+   if (otp) {
+     return {
+       token: otp,
+-      isRequired: Promise.resolve(true)
++      isRequired: Promise.resolve(true),
+     };
+   }
+ 
+-  if (ciInfo.isCI || publicPackages.some(pkg => {
+-    var _pkg$packageJson$publ;
+-
+-    return isCustomRegistry((_pkg$packageJson$publ = pkg.packageJson.publishConfig) === null || _pkg$packageJson$publ === void 0 ? void 0 : _pkg$packageJson$publ.registry);
+-  }) || isCustomRegistry(process.env.npm_config_registry)) {
++  if (
++    ciInfo.isCI ||
++    publicPackages.some((pkg) => {
++      var _pkg$packageJson$publ;
++
++      return isCustomRegistry(
++        (_pkg$packageJson$publ = pkg.packageJson.publishConfig) === null ||
++          _pkg$packageJson$publ === void 0
++          ? void 0
++          : _pkg$packageJson$publ.registry
++      );
++    }) ||
++    isCustomRegistry(process.env.npm_config_registry)
++  ) {
+     return {
+       token: null,
+-      isRequired: Promise.resolve(false)
++      isRequired: Promise.resolve(false),
+     };
+   }
+ 
+   return {
+     token: null,
+     // note: we're not awaiting this here, we want this request to happen in parallel with getUnpublishedPackages
+-    isRequired: getTokenIsRequired()
++    isRequired: getTokenIsRequired(),
+   };
+ };
+ 
+-async function publishPackages({
+-  packages,
+-  access,
+-  otp,
+-  preState,
+-  tag
+-}) {
+-  const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]));
+-  const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
+-  const unpublishedPackagesInfo = await getUnpublishedPackages(publicPackages, preState);
++async function publishPackages({ packages, access, otp, preState, tag }) {
++  const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
++  const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
++  const unpublishedPackagesInfo = await getUnpublishedPackages(
++    publicPackages,
++    preState
++  );
+ 
+   if (unpublishedPackagesInfo.length === 0) {
+     return [];
+@@ -920,78 +1270,109 @@ async function publishPackages({
+ 
+   const twoFactorState = getTwoFactorState({
+     otp,
+-    publicPackages
++    publicPackages,
+   });
+-  return Promise.all(unpublishedPackagesInfo.map(pkgInfo => {
+-    let pkg = packagesByName.get(pkgInfo.name);
+-    return publishAPackage(pkg, access, twoFactorState, getReleaseTag(pkgInfo, preState, tag));
+-  }));
++  return Promise.all(
++    unpublishedPackagesInfo.map((pkgInfo) => {
++      let pkg = packagesByName.get(pkgInfo.name);
++      return publishAPackage(
++        pkg,
++        access,
++        twoFactorState,
++        getReleaseTag(pkgInfo, preState, tag)
++      );
++    })
++  );
+ }
+ 
+ async function publishAPackage(pkg, access, twoFactorState, tag) {
+-  const {
++  const { name, version, publishConfig } = pkg.packageJson;
++  logger.info(
++    `Publishing ${chalk__default["default"].cyan(
++      `"${name}"`
++    )} at ${chalk__default["default"].green(`"${version}"`)}`
++  );
++  const publishConfirmation = await publish(
+     name,
+-    version,
+-    publishConfig
+-  } = pkg.packageJson;
+-  logger.info(`Publishing ${chalk__default["default"].cyan(`"${name}"`)} at ${chalk__default["default"].green(`"${version}"`)}`);
+-  const publishConfirmation = await publish(name, {
+-    cwd: pkg.dir,
+-    publishDir: publishConfig !== null && publishConfig !== void 0 && publishConfig.directory ? path.join(pkg.dir, publishConfig.directory) : pkg.dir,
+-    access: (publishConfig === null || publishConfig === void 0 ? void 0 : publishConfig.access) || access,
+-    tag
+-  }, twoFactorState);
++    {
++      cwd: pkg.dir,
++      publishDir:
++        publishConfig !== null &&
++        publishConfig !== void 0 &&
++        publishConfig.directory
++          ? path.join(pkg.dir, publishConfig.directory)
++          : pkg.dir,
++      access:
++        (publishConfig === null || publishConfig === void 0
++          ? void 0
++          : publishConfig.access) || access,
++      tag,
++    },
++    twoFactorState
++  );
+   return {
+     name,
+     newVersion: version,
+-    published: publishConfirmation.published
++    published: publishConfirmation.published,
+   };
+ }
+ 
+ async function getUnpublishedPackages(packages, preState) {
+-  const results = await Promise.all(packages.map(async ({
+-    packageJson
+-  }) => {
+-    const response = await infoAllow404(packageJson);
+-    let publishedState = "never";
+-
+-    if (response.published) {
+-      publishedState = "published";
+-
+-      if (preState !== undefined) {
+-        if (response.pkgInfo.versions && response.pkgInfo.versions.every(version => semverParse__default["default"](version).prerelease[0] === preState.tag)) {
+-          publishedState = "only-pre";
++  const results = await Promise.all(
++    packages.map(async ({ packageJson }) => {
++      const response = await infoAllow404(packageJson);
++      let publishedState = "never";
++
++      if (response.published) {
++        publishedState = "published";
++
++        if (preState !== undefined) {
++          if (
++            response.pkgInfo.versions &&
++            response.pkgInfo.versions.every(
++              (version) =>
++                semverParse__default["default"](version).prerelease[0] ===
++                preState.tag
++            )
++          ) {
++            publishedState = "only-pre";
++          }
+         }
+       }
+-    }
+ 
+-    return {
+-      name: packageJson.name,
+-      localVersion: packageJson.version,
+-      publishedState,
+-      publishedVersions: response.pkgInfo.versions || []
+-    };
+-  }));
++      return {
++        name: packageJson.name,
++        localVersion: packageJson.version,
++        publishedState,
++        publishedVersions: response.pkgInfo.versions || [],
++      };
++    })
++  );
+   const packagesToPublish = [];
+ 
+   for (const pkgInfo of results) {
+-    const {
+-      name,
+-      publishedState,
+-      localVersion,
+-      publishedVersions
+-    } = pkgInfo;
++    const { name, publishedState, localVersion, publishedVersions } = pkgInfo;
+ 
+     if (!publishedVersions.includes(localVersion)) {
+       packagesToPublish.push(pkgInfo);
+-      logger.info(`${name} is being published because our local version (${localVersion}) has not been published on npm`);
++      logger.info(
++        `${name} is being published because our local version (${localVersion}) has not been published on npm`
++      );
+ 
+       if (preState !== undefined && publishedState === "only-pre") {
+-        logger.info(`${name} is being published to ${chalk__default["default"].cyan("latest")} rather than ${chalk__default["default"].cyan(preState.tag)} because there has not been a regular release of it yet`);
++        logger.info(
++          `${name} is being published to ${chalk__default["default"].cyan(
++            "latest"
++          )} rather than ${chalk__default["default"].cyan(
++            preState.tag
++          )} because there has not been a regular release of it yet`
++        );
+       }
+     } else {
+       // If the local version is behind npm, something is wrong, we warn here, and by not getting published later, it will fail
+-      logger.warn(`${name} is not being published because version ${localVersion} is already published on npm`);
++      logger.warn(
++        `${name} is not being published because version ${localVersion} is already published on npm`
++      );
+     }
+   }
+ 
+@@ -999,14 +1380,22 @@ async function getUnpublishedPackages(packages, preState) {
+ }
+ 
+ async function getUntaggedPrivatePackages(privatePackages, cwd, tool) {
+-  const packageWithTags = await Promise.all(privatePackages.map(async privatePkg => {
+-    const tagName = tool === "root" ? `v${privatePkg.packageJson.version}` : `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
+-    const isMissingTag = !((await git__namespace.tagExists(tagName, cwd)) || (await git__namespace.remoteTagExists(tagName)));
+-    return {
+-      pkg: privatePkg,
+-      isMissingTag
+-    };
+-  }));
++  const packageWithTags = await Promise.all(
++    privatePackages.map(async (privatePkg) => {
++      const tagName =
++        tool === "root"
++          ? `v${privatePkg.packageJson.version}`
++          : `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
++      const isMissingTag = !(
++        (await git__namespace.tagExists(tagName, cwd)) ||
++        (await git__namespace.remoteTagExists(tagName))
++      );
++      return {
++        pkg: privatePkg,
++        isMissingTag,
++      };
++    })
++  );
+   const untagged = [];
+ 
+   for (const packageWithTag of packageWithTags) {
+@@ -1014,7 +1403,7 @@ async function getUntaggedPrivatePackages(privatePackages, cwd, tool) {
+       untagged.push({
+         name: packageWithTag.pkg.packageJson.name,
+         newVersion: packageWithTag.pkg.packageJson.version,
+-        published: false
++        published: false,
+       });
+     }
+   }
+@@ -1023,19 +1412,27 @@ async function getUntaggedPrivatePackages(privatePackages, cwd, tool) {
+ }
+ 
+ function logReleases(pkgs) {
+-  const mappedPkgs = pkgs.map(p => `${p.name}@${p.newVersion}`).join("\n");
++  const mappedPkgs = pkgs.map((p) => `${p.name}@${p.newVersion}`).join("\n");
+   logger.log(mappedPkgs);
+ }
+ 
+-let importantSeparator = chalk__default["default"].red("===============================IMPORTANT!===============================");
+-let importantEnd = chalk__default["default"].red("----------------------------------------------------------------------");
++let importantSeparator = chalk__default["default"].red(
++  "===============================IMPORTANT!==============================="
++);
++let importantEnd = chalk__default["default"].red(
++  "----------------------------------------------------------------------"
++);
+ 
+ function showNonLatestTagWarning(tag, preState) {
+   logger.warn(importantSeparator);
+ 
+   if (preState) {
+-    logger.warn(`You are in prerelease mode so packages will be published to the ${chalk__default["default"].cyan(preState.tag)}
+-        dist tag except for packages that have not had normal releases which will be published to ${chalk__default["default"].cyan("latest")}`);
++    logger.warn(`You are in prerelease mode so packages will be published to the ${chalk__default[
++      "default"
++    ].cyan(preState.tag)}
++        dist tag except for packages that have not had normal releases which will be published to ${chalk__default[
++          "default"
++        ].cyan("latest")}`);
+   } else if (tag !== "latest") {
+     logger.warn(`Packages will be released under the ${tag} tag`);
+   }
+@@ -1043,17 +1440,15 @@ function showNonLatestTagWarning(tag, preState) {
+   logger.warn(importantEnd);
+ }
+ 
+-async function run$2(cwd, {
+-  otp,
+-  tag,
+-  gitTag = true
+-}, config) {
++async function run$2(cwd, { otp, tag, gitTag = true }, config) {
+   const releaseTag = tag && tag.length > 0 ? tag : undefined;
+   let preState = await pre$1.readPreState(cwd);
+ 
+   if (releaseTag && preState && preState.mode === "pre") {
+     logger.error("Releasing under custom tag is not allowed in pre mode");
+-    logger.log("To resolve this exit the pre mode by running `changeset pre exit`");
++    logger.log(
++      "To resolve this exit the pre mode by running `changeset pre exit`"
++    );
+     throw new errors.ExitError(1);
+   }
+ 
+@@ -1061,28 +1456,35 @@ async function run$2(cwd, {
+     showNonLatestTagWarning(tag, preState);
+   }
+ 
+-  const {
+-    packages,
+-    tool
+-  } = await getPackages.getPackages(cwd);
+-  const tagPrivatePackages = config.privatePackages && config.privatePackages.tag;
++  const { packages, tool } = await getPackages.getPackages(cwd);
++  const tagPrivatePackages =
++    config.privatePackages && config.privatePackages.tag;
+   const publishedPackages = await publishPackages({
+     packages,
+     // if not public, we won't pass the access, and it works as normal
+     access: config.access,
+     otp,
+     preState,
+-    tag: releaseTag
++    tag: releaseTag,
+   });
+-  const privatePackages = packages.filter(pkg => pkg.packageJson.private && pkg.packageJson.version);
+-  const untaggedPrivatePackageReleases = tagPrivatePackages ? await getUntaggedPrivatePackages(privatePackages, cwd, tool) : [];
+-
+-  if (publishedPackages.length === 0 && untaggedPrivatePackageReleases.length === 0) {
++  const privatePackages = packages.filter(
++    (pkg) => pkg.packageJson.private && pkg.packageJson.version
++  );
++  const untaggedPrivatePackageReleases = tagPrivatePackages
++    ? await getUntaggedPrivatePackages(privatePackages, cwd, tool)
++    : [];
++
++  if (
++    publishedPackages.length === 0 &&
++    untaggedPrivatePackageReleases.length === 0
++  ) {
+     logger.warn("No unpublished projects to publish");
+   }
+ 
+-  const successfulNpmPublishes = publishedPackages.filter(p => p.published);
+-  const unsuccessfulNpmPublishes = publishedPackages.filter(p => !p.published);
++  const successfulNpmPublishes = publishedPackages.filter((p) => p.published);
++  const unsuccessfulNpmPublishes = publishedPackages.filter(
++    (p) => !p.published
++  );
+ 
+   if (successfulNpmPublishes.length > 0) {
+     logger.success("packages published successfully:");
+@@ -1092,7 +1494,9 @@ async function run$2(cwd, {
+       // We create the tags after the push above so that we know that HEAD won't change and that pushing
+       // won't suffer from a race condition if another merge happens in the mean time (pushing tags won't
+       // fail if we are behind the base branch).
+-      logger.log(`Creating git tag${successfulNpmPublishes.length > 1 ? "s" : ""}...`);
++      logger.log(
++        `Creating git tag${successfulNpmPublishes.length > 1 ? "s" : ""}...`
++      );
+       await tagPublish(tool, successfulNpmPublishes, cwd);
+     }
+   }
+@@ -1124,37 +1528,43 @@ async function tagPublish(tool, packageReleases, cwd) {
+   }
+ }
+ 
+-async function getStatus(cwd, {
+-  sinceMaster,
+-  since,
+-  verbose,
+-  output
+-}, config) {
++async function getStatus(cwd, { sinceMaster, since, verbose, output }, config) {
+   if (sinceMaster) {
+-    logger.warn("--sinceMaster is deprecated and will be removed in a future major version");
++    logger.warn(
++      "--sinceMaster is deprecated and will be removed in a future major version"
++    );
+     logger.warn("Use --since=master instead");
+   }
+ 
+-  const sinceBranch = since === undefined ? sinceMaster ? "master" : undefined : since;
+-  const releasePlan = await getReleasePlan__default["default"](cwd, sinceBranch, config);
+-  const {
+-    changesets,
+-    releases
+-  } = releasePlan;
++  const sinceBranch =
++    since === undefined ? (sinceMaster ? "master" : undefined) : since;
++  const releasePlan = await getReleasePlan__default["default"](
++    cwd,
++    sinceBranch,
++    config
++  );
++  const { changesets, releases } = releasePlan;
+   const changedPackages = await git__namespace.getChangedPackagesSinceRef({
+     cwd,
+     ref: sinceBranch || config.baseBranch,
+-    changedFilePatterns: config.changedFilePatterns
++    changedFilePatterns: config.changedFilePatterns,
+   });
+ 
+   if (changedPackages.length > 0 && changesets.length === 0) {
+-    logger.error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.");
+-    logger.error("If this change doesn't need a release, run `changeset add --empty`.");
++    logger.error(
++      "Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error."
++    );
++    logger.error(
++      "If this change doesn't need a release, run `changeset add --empty`."
++    );
+     process.exit(1);
+   }
+ 
+   if (output) {
+-    await fs__default["default"].writeFile(path__default["default"].join(cwd, output), JSON.stringify(releasePlan, undefined, 2));
++    await fs__default["default"].writeFile(
++      path__default["default"].join(cwd, output),
++      JSON.stringify(releasePlan, undefined, 2)
++    );
+     return;
+   }
+ 
+@@ -1168,47 +1578,69 @@ async function getStatus(cwd, {
+ }
+ 
+ function SimplePrint(type, releases) {
+-  const packages = releases.filter(r => r.type === type);
++  const packages = releases.filter((r) => r.type === type);
+ 
+   if (packages.length) {
+-    logger.info(chalk__default["default"]`Packages to be bumped at {green ${type}}:\n`);
+-    const pkgs = packages.map(({
+-      name
+-    }) => `- ${name}`).join("\n");
++    logger.info(
++      chalk__default["default"]`Packages to be bumped at {green ${type}}:\n`
++    );
++    const pkgs = packages.map(({ name }) => `- ${name}`).join("\n");
+     logger.log(chalk__default["default"].green(pkgs));
+   } else {
+-    logger.info(chalk__default["default"]`{red NO} packages to be bumped at {green ${type}}`);
++    logger.info(
++      chalk__default[
++        "default"
++      ]`{red NO} packages to be bumped at {green ${type}}`
++    );
+   }
+ }
+ 
+ function verbosePrint(type, releases) {
+-  const packages = releases.filter(r => r.type === type);
++  const packages = releases.filter((r) => r.type === type);
+ 
+   if (packages.length) {
+-    logger.info(chalk__default["default"]`Packages to be bumped at {green ${type}}`);
+-    const columns = packages.map(({
+-      name,
+-      newVersion: version,
+-      changesets
+-    }) => [chalk__default["default"].green(name), version, changesets.map(c => chalk__default["default"].blue(` .changeset/${c}.md`)).join(" +")]);
+-    const t1 = table__default["default"]([{
+-      value: "Package Name",
+-      width: 20
+-    }, {
+-      value: "New Version",
+-      width: 20
+-    }, {
+-      value: "Related Changeset Summaries",
+-      width: 70
+-    }], columns, {
+-      paddingLeft: 1,
+-      paddingRight: 0,
+-      headerAlign: "center",
+-      align: "left"
+-    });
++    logger.info(
++      chalk__default["default"]`Packages to be bumped at {green ${type}}`
++    );
++    const columns = packages.map(
++      ({ name, newVersion: version, changesets }) => [
++        chalk__default["default"].green(name),
++        version,
++        changesets
++          .map((c) => chalk__default["default"].blue(` .changeset/${c}.md`))
++          .join(" +"),
++      ]
++    );
++    const t1 = table__default["default"](
++      [
++        {
++          value: "Package Name",
++          width: 20,
++        },
++        {
++          value: "New Version",
++          width: 20,
++        },
++        {
++          value: "Related Changeset Summaries",
++          width: 70,
++        },
++      ],
++      columns,
++      {
++        paddingLeft: 1,
++        paddingRight: 0,
++        headerAlign: "center",
++        align: "left",
++      }
++    );
+     logger.log(t1.render() + "\n");
+   } else {
+-    logger.info(chalk__default["default"]`Running release would release {red NO} packages as a {green ${type}}`);
++    logger.info(
++      chalk__default[
++        "default"
++      ]`Running release would release {red NO} packages as a {green ${type}}`
++    );
+   }
+ }
+ 
+@@ -1216,12 +1648,22 @@ async function pre(cwd, options) {
+   if (options.command === "enter") {
+     try {
+       await pre$1.enterPre(cwd, options.tag);
+-      logger__namespace.success(`Entered pre mode with tag ${chalk__default["default"].cyan(options.tag)}`);
+-      logger__namespace.info("Run `changeset version` to version packages with prerelease versions");
++      logger__namespace.success(
++        `Entered pre mode with tag ${chalk__default["default"].cyan(
++          options.tag
++        )}`
++      );
++      logger__namespace.info(
++        "Run `changeset version` to version packages with prerelease versions"
++      );
+     } catch (err) {
+       if (err instanceof errors.PreEnterButInPreModeError) {
+-        logger__namespace.error("`changeset pre enter` cannot be run when in pre mode");
+-        logger__namespace.info("If you're trying to exit pre mode, run `changeset pre exit`");
++        logger__namespace.error(
++          "`changeset pre enter` cannot be run when in pre mode"
++        );
++        logger__namespace.info(
++          "If you're trying to exit pre mode, run `changeset pre exit`"
++        );
+         throw new errors.ExitError(1);
+       }
+ 
+@@ -1231,11 +1673,17 @@ async function pre(cwd, options) {
+     try {
+       await pre$1.exitPre(cwd);
+       logger__namespace.success(`Exited pre mode`);
+-      logger__namespace.info("Run `changeset version` to version packages with normal versions");
++      logger__namespace.info(
++        "Run `changeset version` to version packages with normal versions"
++      );
+     } catch (err) {
+       if (err instanceof errors.PreExitButNotInPreModeError) {
+-        logger__namespace.error("`changeset pre exit` can only be run when in pre mode");
+-        logger__namespace.info("If you're trying to enter pre mode, run `changeset pre enter`");
++        logger__namespace.error(
++          "`changeset pre exit` can only be run when in pre mode"
++        );
++        logger__namespace.info(
++          "If you're trying to enter pre mode, run `changeset pre enter`"
++        );
+         throw new errors.ExitError(1);
+       }
+ 
+@@ -1245,14 +1693,14 @@ async function pre(cwd, options) {
+ }
+ 
+ async function run$1(cwd) {
+-  const {
+-    packages,
+-    tool
+-  } = await getPackages.getPackages(cwd);
++  const { packages, tool } = await getPackages.getPackages(cwd);
+   const allExistingTags = await git__namespace.getAllTags(cwd);
+ 
+   for (const pkg of packages) {
+-    const tag = tool !== "root" ? `${pkg.packageJson.name}@${pkg.packageJson.version}` : `v${pkg.packageJson.version}`;
++    const tag =
++      tool !== "root"
++        ? `${pkg.packageJson.name}@${pkg.packageJson.version}`
++        : `v${pkg.packageJson.version}`;
+ 
+     if (allExistingTags.has(tag)) {
+       logger.log("Skipping tag (already exists): ", tag);
+@@ -1269,10 +1717,18 @@ async function run(input, flags, cwd) {
+     return;
+   }
+ 
+-  if (!fs__default["default"].existsSync(path__default["default"].resolve(cwd, ".changeset"))) {
++  if (
++    !fs__default["default"].existsSync(
++      path__default["default"].resolve(cwd, ".changeset")
++    )
++  ) {
+     logger.error("There is no .changeset folder. ");
+-    logger.error("If this is the first time `changesets` have been used in this project, run `yarn changeset init` to get set up.");
+-    logger.error("If you expected there to be changesets, you should check git history for when the folder was removed to ensure you do not lose any configuration.");
++    logger.error(
++      "If this is the first time `changesets` have been used in this project, run `yarn changeset init` to get set up."
++    );
++    logger.error(
++      "If you expected there to be changesets, you should check git history for when the folder was removed to ensure you do not lose any configuration."
++    );
+     throw new errors.ExitError(1);
+   }
+ 
+@@ -1282,13 +1738,23 @@ async function run(input, flags, cwd) {
+   try {
+     config$1 = await config.read(cwd, packages);
+   } catch (e) {
+-    let oldConfigExists = await fs__default["default"].pathExists(path__default["default"].resolve(cwd, ".changeset/config.js"));
++    let oldConfigExists = await fs__default["default"].pathExists(
++      path__default["default"].resolve(cwd, ".changeset/config.js")
++    );
+ 
+     if (oldConfigExists) {
+-      logger.error("It looks like you're using the version 1 `.changeset/config.js` file");
+-      logger.error("You'll need to convert it to a `.changeset/config.json` file");
+-      logger.error("The format of the config object has significantly changed in v2 as well");
+-      logger.error(" - we thoroughly recommend looking at the changelog for this package for what has changed");
++      logger.error(
++        "It looks like you're using the version 1 `.changeset/config.js` file"
++      );
++      logger.error(
++        "You'll need to convert it to a `.changeset/config.json` file"
++      );
++      logger.error(
++        "The format of the config object has significantly changed in v2 as well"
++      );
++      logger.error(
++        " - we thoroughly recommend looking at the changelog for this package for what has changed"
++      );
+       throw new errors.ExitError(1);
+     } else {
+       throw e;
+@@ -1296,17 +1762,20 @@ async function run(input, flags, cwd) {
+   }
+ 
+   if (input.length < 1) {
+-    const {
+-      empty,
+-      open
+-    } = flags; // @ts-ignore if this is undefined, we have already exited
++    const { empty, open } = flags; // @ts-ignore if this is undefined, we have already exited
+ 
+-    await add(cwd, {
+-      empty,
+-      open
+-    }, config$1);
++    await add(
++      cwd,
++      {
++        empty,
++        open,
++      },
++      config$1
++    );
+   } else if (input[0] !== "pre" && input.length > 1) {
+-    logger.error("Too many arguments passed to changesets - we only accept the command name as an argument");
++    logger.error(
++      "Too many arguments passed to changesets - we only accept the command name as an argument"
++    );
+   } else {
+     const {
+       sinceMaster,
+@@ -1320,12 +1789,14 @@ async function run(input, flags, cwd) {
+       snapshotPrereleaseTemplate,
+       tag,
+       open,
+-      gitTag
++      gitTag,
+     } = flags;
+     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
+-    deadFlags.forEach(flag => {
++    deadFlags.forEach((flag) => {
+       if (flags[flag]) {
+-        logger.error(`the flag ${flag} has been removed from changesets for version 2`);
++        logger.error(
++          `the flag ${flag} has been removed from changesets for version 2`
++        );
+         logger.error(`Please encode the desired value into your config`);
+         logger.error(`See our changelog for more details`);
+         throw new errors.ExitError(1);
+@@ -1336,153 +1807,175 @@ async function run(input, flags, cwd) {
+     // object as and when they exist.
+ 
+     switch (input[0]) {
+-      case "add":
+-        {
+-          await add(cwd, {
++      case "add": {
++        await add(
++          cwd,
++          {
+             empty,
+-            open
+-          }, config$1);
+-          return;
+-        }
+-
+-      case "version":
+-        {
+-          let ignoreArrayFromCmd;
+-
+-          if (typeof ignore === "string") {
+-            ignoreArrayFromCmd = [ignore];
+-          } else {
+-            // undefined or an array
+-            ignoreArrayFromCmd = ignore;
+-          } // Validate that items in ignoreArrayFromCmd are valid project names
+-
+-
+-          let pkgNames = new Set(packages.packages.map(({
+-            packageJson
+-          }) => packageJson.name));
+-          const messages = [];
++            open,
++          },
++          config$1
++        );
++        return;
++      }
+ 
+-          for (const pkgName of ignoreArrayFromCmd || []) {
+-            if (!pkgNames.has(pkgName)) {
+-              messages.push(`The package "${pkgName}" is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`);
+-            }
++      case "version": {
++        let ignoreArrayFromCmd;
++
++        if (typeof ignore === "string") {
++          ignoreArrayFromCmd = [ignore];
++        } else {
++          // undefined or an array
++          ignoreArrayFromCmd = ignore;
++        } // Validate that items in ignoreArrayFromCmd are valid project names
++
++        let pkgNames = new Set(
++          packages.packages.map(({ packageJson }) => packageJson.name)
++        );
++        const messages = [];
++
++        for (const pkgName of ignoreArrayFromCmd || []) {
++          if (!pkgNames.has(pkgName)) {
++            messages.push(
++              `The package "${pkgName}" is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`
++            );
+           }
++        }
+ 
+-          if (config$1.ignore.length > 0 && ignoreArrayFromCmd) {
+-            messages.push(`It looks like you are trying to use the \`--ignore\` option while ignore is defined in the config file. This is currently not allowed, you can only use one of them at a time.`);
+-          } else if (ignoreArrayFromCmd) {
+-            // use the ignore flags from cli
+-            config$1.ignore = ignoreArrayFromCmd;
+-          } // Validate that all dependents of ignored packages are listed in the ignore list
+-
+-
+-          const dependentsGraph = getDependentsGraph.getDependentsGraph(packages, {
+-            bumpVersionsWithWorkspaceProtocolOnly: config$1.bumpVersionsWithWorkspaceProtocolOnly
+-          });
++        if (config$1.ignore.length > 0 && ignoreArrayFromCmd) {
++          messages.push(
++            `It looks like you are trying to use the \`--ignore\` option while ignore is defined in the config file. This is currently not allowed, you can only use one of them at a time.`
++          );
++        } else if (ignoreArrayFromCmd) {
++          // use the ignore flags from cli
++          config$1.ignore = ignoreArrayFromCmd;
++        } // Validate that all dependents of ignored packages are listed in the ignore list
++
++        const dependentsGraph = getDependentsGraph.getDependentsGraph(
++          packages,
++          {
++            bumpVersionsWithWorkspaceProtocolOnly:
++              config$1.bumpVersionsWithWorkspaceProtocolOnly,
++          }
++        );
+ 
+-          for (const ignoredPackage of config$1.ignore) {
+-            const dependents = dependentsGraph.get(ignoredPackage) || [];
++        for (const ignoredPackage of config$1.ignore) {
++          const dependents = dependentsGraph.get(ignoredPackage) || [];
+ 
+-            for (const dependent of dependents) {
+-              if (!config$1.ignore.includes(dependent)) {
+-                messages.push(`The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please pass "${dependent}" to the \`--ignore\` flag.`);
+-              }
++          for (const dependent of dependents) {
++            if (!config$1.ignore.includes(dependent)) {
++              messages.push(
++                `The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please pass "${dependent}" to the \`--ignore\` flag.`
++              );
+             }
+           }
++        }
+ 
+-          if (messages.length > 0) {
+-            logger.error(messages.join("\n"));
+-            throw new errors.ExitError(1);
+-          }
+-
+-          if (snapshotPrereleaseTemplate) {
+-            config$1.snapshot.prereleaseTemplate = snapshotPrereleaseTemplate;
+-          }
++        if (messages.length > 0) {
++          logger.error(messages.join("\n"));
++          throw new errors.ExitError(1);
++        }
+ 
+-          await version(cwd, {
+-            snapshot
+-          }, config$1);
+-          return;
++        if (snapshotPrereleaseTemplate) {
++          config$1.snapshot.prereleaseTemplate = snapshotPrereleaseTemplate;
+         }
+ 
+-      case "publish":
+-        {
+-          await run$2(cwd, {
++        await version(
++          cwd,
++          {
++            snapshot,
++          },
++          config$1
++        );
++        return;
++      }
++
++      case "publish": {
++        await run$2(
++          cwd,
++          {
+             otp,
+             tag,
+-            gitTag
+-          }, config$1);
+-          return;
+-        }
++            gitTag,
++          },
++          config$1
++        );
++        return;
++      }
+ 
+-      case "status":
+-        {
+-          await getStatus(cwd, {
++      case "status": {
++        await getStatus(
++          cwd,
++          {
+             sinceMaster,
+             since,
+             verbose,
+-            output
+-          }, config$1);
+-          return;
+-        }
+-
+-      case "tag":
+-        {
+-          await run$1(cwd);
+-          return;
+-        }
++            output,
++          },
++          config$1
++        );
++        return;
++      }
+ 
+-      case "pre":
+-        {
+-          let command = input[1];
++      case "tag": {
++        await run$1(cwd);
++        return;
++      }
+ 
+-          if (command !== "enter" && command !== "exit") {
+-            logger.error("`enter`, `exit` or `snapshot` must be passed after prerelease");
+-            throw new errors.ExitError(1);
+-          }
++      case "pre": {
++        let command = input[1];
+ 
+-          let tag = input[2];
++        if (command !== "enter" && command !== "exit") {
++          logger.error(
++            "`enter`, `exit` or `snapshot` must be passed after prerelease"
++          );
++          throw new errors.ExitError(1);
++        }
+ 
+-          if (command === "enter" && typeof tag !== "string") {
+-            logger.error(`A tag must be passed when using prerelese enter`);
+-            throw new errors.ExitError(1);
+-          } // @ts-ignore
++        let tag = input[2];
+ 
++        if (command === "enter" && typeof tag !== "string") {
++          logger.error(`A tag must be passed when using prerelese enter`);
++          throw new errors.ExitError(1);
++        } // @ts-ignore
+ 
+-          await pre(cwd, {
+-            command,
+-            tag
+-          });
+-          return;
+-        }
++        await pre(cwd, {
++          command,
++          tag,
++        });
++        return;
++      }
+ 
+-      case "bump":
+-        {
+-          logger.error('In version 2 of changesets, "bump" has been renamed to "version" - see our changelog for an explanation');
+-          logger.error("To fix this, use `changeset version` instead, and update any scripts that use changesets");
+-          throw new errors.ExitError(1);
+-        }
++      case "bump": {
++        logger.error(
++          'In version 2 of changesets, "bump" has been renamed to "version" - see our changelog for an explanation'
++        );
++        logger.error(
++          "To fix this, use `changeset version` instead, and update any scripts that use changesets"
++        );
++        throw new errors.ExitError(1);
++      }
+ 
+-      case "release":
+-        {
+-          logger.error('In version 2 of changesets, "release" has been renamed to "publish" - see our changelog for an explanation');
+-          logger.error("To fix this, use `changeset publish` instead, and update any scripts that use changesets");
+-          throw new errors.ExitError(1);
+-        }
++      case "release": {
++        logger.error(
++          'In version 2 of changesets, "release" has been renamed to "publish" - see our changelog for an explanation'
++        );
++        logger.error(
++          "To fix this, use `changeset publish` instead, and update any scripts that use changesets"
++        );
++        throw new errors.ExitError(1);
++      }
+ 
+-      default:
+-        {
+-          logger.error(`Invalid command ${input[0]} was provided`);
+-          throw new errors.ExitError(1);
+-        }
++      default: {
++        logger.error(`Invalid command ${input[0]} was provided`);
++        throw new errors.ExitError(1);
++      }
+     }
+   }
+ }
+ 
+-const {
+-  input,
+-  flags
+-} = meow__default["default"](`
++const { input, flags } = meow__default["default"](
++  `
+   Usage
+     $ changeset [command]
+   Commands
+@@ -1493,56 +1986,62 @@ const {
+     status [--since <branch>] [--verbose] [--output JSON_FILE.json]
+     pre <enter|exit> <tag>
+     tag
+-    `, {
+-  flags: {
+-    sinceMaster: {
+-      type: "boolean"
+-    },
+-    verbose: {
+-      type: "boolean",
+-      alias: "v"
++    `,
++  {
++    flags: {
++      sinceMaster: {
++        type: "boolean",
++      },
++      verbose: {
++        type: "boolean",
++        alias: "v",
++      },
++      output: {
++        type: "string",
++        alias: "o",
++      },
++      otp: {
++        type: "string",
++      },
++      empty: {
++        type: "boolean",
++      },
++      since: {
++        type: "string",
++      },
++      ignore: {
++        type: "string",
++        isMultiple: true,
++      },
++      tag: {
++        type: "string",
++      },
++      open: {
++        type: "boolean",
++      },
++      gitTag: {
++        type: "boolean",
++        default: true,
++      },
++      snapshotPrereleaseTemplate: {
++        type: "string",
++      }, // mixed type like this is not supported by `meow`
++      // if it gets passed explicitly then it's still available on the flags with an inferred type though
++      // snapshot: { type: "boolean" | "string" },
+     },
+-    output: {
+-      type: "string",
+-      alias: "o"
+-    },
+-    otp: {
+-      type: "string"
+-    },
+-    empty: {
+-      type: "boolean"
+-    },
+-    since: {
+-      type: "string"
+-    },
+-    ignore: {
+-      type: "string",
+-      isMultiple: true
+-    },
+-    tag: {
+-      type: "string"
+-    },
+-    open: {
+-      type: "boolean"
+-    },
+-    gitTag: {
+-      type: "boolean",
+-      default: true
+-    },
+-    snapshotPrereleaseTemplate: {
+-      type: "string"
+-    } // mixed type like this is not supported by `meow`
+-    // if it gets passed explicitly then it's still available on the flags with an inferred type though
+-    // snapshot: { type: "boolean" | "string" },
+-
+   }
+-});
++);
+ const cwd = process.cwd();
+-run(input, flags, cwd).catch(err => {
++run(input, flags, cwd).catch((err) => {
+   if (err instanceof errors.InternalError) {
+-    logger.error("The following error is an internal unexpected error, these should never happen.");
++    logger.error(
++      "The following error is an internal unexpected error, these should never happen."
++    );
+     logger.error("Please open an issue with the following link");
+-    logger.error(`https://github.com/changesets/changesets/issues/new?title=${encodeURIComponent(`Unexpected error during ${input[0] || "add"} command`)}&body=${encodeURIComponent(`## Error
++    logger.error(
++      `https://github.com/changesets/changesets/issues/new?title=${encodeURIComponent(
++        `Unexpected error during ${input[0] || "add"} command`
++      )}&body=${encodeURIComponent(`## Error
+ 
+ \`\`\`
+ ${util.format("", err).replace(process.cwd(), "<cwd>")}
+@@ -1550,14 +2049,17 @@ ${util.format("", err).replace(process.cwd(), "<cwd>")}
+ 
+ ## Versions
+ 
+-- @changesets/cli@${// eslint-disable-next-line import/no-extraneous-dependencies
+-    require("@changesets/cli/package.json").version}
++- @changesets/cli@${
++        // eslint-disable-next-line import/no-extraneous-dependencies
++        require("@changesets/cli/package.json").version
++      }
+ - node@${process.version}
+ 
+ ## Extra details
+ 
+ <!-- Add any extra details of what you were doing, ideas you have about what might have caused the error and reproduction steps if possible. If you have a repository we can look at that would be great. 😁 -->
+-`)}`);
++`)}`
++    );
+   }
+ 
+   if (err instanceof errors.ExitError) {
+diff --git a/dist/changesets-cli.esm.js b/dist/changesets-cli.esm.js
+index 6b0c2cecd33c4ed89bfc964daf3ca5d1e482c1db..ee14d44cc53e5843dfcc7e971fda066b442ba666 100644
+--- a/dist/changesets-cli.esm.js
++++ b/dist/changesets-cli.esm.js
+@@ -1,70 +1,107 @@
+-import meow from 'meow';
+-import { ExitError, PreEnterButInPreModeError, PreExitButNotInPreModeError, InternalError } from '@changesets/errors';
+-import * as logger from '@changesets/logger';
+-import { error, info, warn, log, prefix, success } from '@changesets/logger';
+-import { format } from 'util';
+-import fs from 'fs-extra';
+-import path, { join } from 'path';
+-import { getPackages } from '@manypkg/get-packages';
+-import { getDependentsGraph } from '@changesets/get-dependents-graph';
+-import { defaultWrittenConfig, read } from '@changesets/config';
+-import _objectSpread from '@babel/runtime/helpers/esm/objectSpread2';
+-import chalk from 'chalk';
+-import { spawn } from 'child_process';
+-import termSize from 'term-size';
+-import { prompt } from 'enquirer';
+-import { edit, ExternalEditor } from 'external-editor';
+-import { symbols } from 'ansi-colors';
+-import * as git from '@changesets/git';
+-import { getCurrentCommitId } from '@changesets/git';
+-import writeChangeset from '@changesets/write';
+-import resolveFrom from 'resolve-from';
+-import semverLt from 'semver/functions/lt';
+-import outdent from 'outdent';
+-import applyReleasePlan from '@changesets/apply-release-plan';
+-import readChangesets from '@changesets/read';
+-import assembleReleasePlan from '@changesets/assemble-release-plan';
+-import { readPreState, enterPre, exitPre } from '@changesets/pre';
+-import semverParse from 'semver/functions/parse';
+-import pLimit from 'p-limit';
+-import preferredPM from 'preferred-pm';
+-import spawn$1 from 'spawndamnit';
+-import { isCI } from 'ci-info';
+-import table from 'tty-table';
+-import getReleasePlan from '@changesets/get-release-plan';
++import meow from "meow";
++import {
++  ExitError,
++  PreEnterButInPreModeError,
++  PreExitButNotInPreModeError,
++  InternalError,
++} from "@changesets/errors";
++import * as logger from "@changesets/logger";
++import { error, info, warn, log, prefix, success } from "@changesets/logger";
++import { format } from "util";
++import fs from "fs-extra";
++import path, { join } from "path";
++import { getPackages } from "@manypkg/get-packages";
++import { getDependentsGraph } from "@changesets/get-dependents-graph";
++import { defaultWrittenConfig, read } from "@changesets/config";
++import _objectSpread from "@babel/runtime/helpers/esm/objectSpread2";
++import chalk from "chalk";
++import { spawn } from "child_process";
++import termSize from "term-size";
++import { prompt } from "enquirer";
++import { edit, ExternalEditor } from "external-editor";
++import { symbols } from "ansi-colors";
++import * as git from "@changesets/git";
++import { getCurrentCommitId } from "@changesets/git";
++import writeChangeset from "@changesets/write";
++import resolveFrom from "resolve-from";
++import semverLt from "semver/functions/lt";
++import outdent from "outdent";
++import applyReleasePlan from "@changesets/apply-release-plan";
++import readChangesets from "@changesets/read";
++import assembleReleasePlan from "@changesets/assemble-release-plan";
++import { readPreState, enterPre, exitPre } from "@changesets/pre";
++import semverParse from "semver/functions/parse";
++import pLimit from "p-limit";
++import preferredPM from "preferred-pm";
++import spawn$1 from "spawndamnit";
++import { isCI } from "ci-info";
++import table from "tty-table";
++import getReleasePlan from "@changesets/get-release-plan";
+ 
+ const pkgPath = path.dirname(require.resolve("@changesets/cli/package.json")); // Modify base branch to "main" without changing defaultWrittenConfig since it also serves as a fallback
+ // for config files that don't specify a base branch. Changing that to main would be a breaking change.
+ 
+-const defaultConfig = `${JSON.stringify(_objectSpread(_objectSpread({}, defaultWrittenConfig), {}, {
+-  baseBranch: "main"
+-}), null, 2)}\n`;
++const defaultConfig = `${JSON.stringify(
++  _objectSpread(
++    _objectSpread({}, defaultWrittenConfig),
++    {},
++    {
++      baseBranch: "main",
++    }
++  ),
++  null,
++  2
++)}\n`;
+ async function init(cwd) {
+   const changesetBase = path.resolve(cwd, ".changeset");
+ 
+   if (fs.existsSync(changesetBase)) {
+     if (!fs.existsSync(path.join(changesetBase, "config.json"))) {
+       if (fs.existsSync(path.join(changesetBase, "config.js"))) {
+-        error("It looks like you're using the version 1 `.changeset/config.js` file");
+-        error("The format of the config object has significantly changed in v2 as well");
+-        error(" - we thoroughly recommend looking at the changelog for this package for what has changed");
+-        error("Changesets will write the defaults for the new config, remember to transfer your options into the new config at `.changeset/config.json`");
++        error(
++          "It looks like you're using the version 1 `.changeset/config.js` file"
++        );
++        error(
++          "The format of the config object has significantly changed in v2 as well"
++        );
++        error(
++          " - we thoroughly recommend looking at the changelog for this package for what has changed"
++        );
++        error(
++          "Changesets will write the defaults for the new config, remember to transfer your options into the new config at `.changeset/config.json`"
++        );
+       } else {
+         error("It looks like you don't have a config file");
+-        info("The default config file will be written at `.changeset/config.json`");
++        info(
++          "The default config file will be written at `.changeset/config.json`"
++        );
+       }
+ 
+-      await fs.writeFile(path.resolve(changesetBase, "config.json"), defaultConfig);
++      await fs.writeFile(
++        path.resolve(changesetBase, "config.json"),
++        defaultConfig
++      );
+     } else {
+-      warn("It looks like you already have changesets initialized. You should be able to run changeset commands no problems.");
++      warn(
++        "It looks like you already have changesets initialized. You should be able to run changeset commands no problems."
++      );
+     }
+   } else {
+     await fs.copy(path.resolve(pkgPath, "./default-files"), changesetBase);
+-    await fs.writeFile(path.resolve(changesetBase, "config.json"), defaultConfig);
+-    log(chalk`Thanks for choosing {green changesets} to help manage your versioning and publishing\n`);
++    await fs.writeFile(
++      path.resolve(changesetBase, "config.json"),
++      defaultConfig
++    );
++    log(
++      chalk`Thanks for choosing {green changesets} to help manage your versioning and publishing\n`
++    );
+     log("You should be set up to start using changesets now!\n");
+-    info("We have added a `.changeset` folder, and a couple of files to help you out:");
+-    info(chalk`- {blue .changeset/README.md} contains information about using changesets`);
++    info(
++      "We have added a `.changeset` folder, and a couple of files to help you out:"
++    );
++    info(
++      chalk`- {blue .changeset/README.md} contains information about using changesets`
++    );
+     info(chalk`- {blue .changeset/config.json} is our default config`);
+   }
+ }
+@@ -77,10 +114,10 @@ async function init(cwd) {
+  * At each call, the entire responses object is returned, so we need a unique
+  * identifier for the name every time. This is why we are using serial IDs
+  */
+-const serialId = function () {
++const serialId = (function () {
+   let id = 0;
+   return () => id++;
+-}();
++})();
+ 
+ const limit = Math.max(termSize().rows - 5, 10);
+ 
+@@ -103,64 +140,80 @@ async function askCheckboxPlus(message, choices, format) {
+     onCancel: cancelFlow,
+     symbols: {
+       indicator: symbols.radioOff,
+-      checked: symbols.radioOn
++      checked: symbols.radioOn,
+     },
+ 
+     indicator(state, choice) {
+       return choice.enabled ? state.symbols.checked : state.symbols.indicator;
+-    }
+-
+-  }).then(responses => responses[name]).catch(err => {
+-    error(err);
+-  });
++    },
++  })
++    .then((responses) => responses[name])
++    .catch((err) => {
++      error(err);
++    });
+ }
+ 
+ async function askQuestion(message) {
+   const name = `Question-${serialId()}`;
+-  return prompt([{
+-    type: "input",
+-    message,
+-    name,
+-    prefix,
+-    onCancel: cancelFlow
+-  }]).then(responses => responses[name]).catch(err => {
+-    error(err);
+-  });
++  return prompt([
++    {
++      type: "input",
++      message,
++      name,
++      prefix,
++      onCancel: cancelFlow,
++    },
++  ])
++    .then((responses) => responses[name])
++    .catch((err) => {
++      error(err);
++    });
+ }
+ 
+ function askQuestionWithEditor(message) {
+   const response = edit(message, {
+-    postfix: ".md"
++    postfix: ".md",
+   });
+-  return response.replace(/^#.*\n?/gm, "").replace(/\n+$/g, "").trim();
++  return response
++    .replace(/^#.*\n?/gm, "")
++    .replace(/\n+$/g, "")
++    .trim();
+ }
+ 
+ async function askConfirm(message) {
+   const name = `Confirm-${serialId()}`;
+-  return prompt([{
+-    message,
+-    name,
+-    prefix,
+-    type: "confirm",
+-    initial: true,
+-    onCancel: cancelFlow
+-  }]).then(responses => responses[name]).catch(err => {
+-    error(err);
+-  });
++  return prompt([
++    {
++      message,
++      name,
++      prefix,
++      type: "confirm",
++      initial: true,
++      onCancel: cancelFlow,
++    },
++  ])
++    .then((responses) => responses[name])
++    .catch((err) => {
++      error(err);
++    });
+ }
+ 
+ async function askList(message, choices) {
+   const name = `List-${serialId()}`;
+-  return prompt([{
+-    choices,
+-    message,
+-    name,
+-    prefix,
+-    type: "select",
+-    onCancel: cancelFlow
+-  }]).then(responses => responses[name]).catch(err => {
+-    error(err);
+-  });
++  return prompt([
++    {
++      choices,
++      message,
++      name,
++      prefix,
++      type: "select",
++      onCancel: cancelFlow,
++    },
++  ])
++    .then((responses) => responses[name])
++    .catch((err) => {
++      error(err);
++    });
+ }
+ 
+ function getCommitFunctions(commit, cwd) {
+@@ -180,7 +233,10 @@ function getCommitFunctions(commit, cwd) {
+     possibleCommitFunc = possibleCommitFunc.default;
+   }
+ 
+-  if (typeof possibleCommitFunc.getAddMessage === "function" || typeof possibleCommitFunc.getVersionMessage === "function") {
++  if (
++    typeof possibleCommitFunc.getAddMessage === "function" ||
++    typeof possibleCommitFunc.getVersionMessage === "function"
++  ) {
+     commitFunctions = possibleCommitFunc;
+   } else {
+     throw new Error("Could not resolve commit generation functions");
+@@ -189,21 +245,26 @@ function getCommitFunctions(commit, cwd) {
+   return [commitFunctions, commitOpts];
+ }
+ 
+-const {
+-  green,
+-  yellow,
+-  red,
+-  bold,
+-  blue,
+-  cyan
+-} = chalk;
++const { green, yellow, red, bold, blue, cyan } = chalk;
+ 
+ async function confirmMajorRelease(pkgJSON) {
+   if (semverLt(pkgJSON.version, "1.0.0")) {
+     // prettier-ignore
+     log(yellow(`WARNING: Releasing a major version for ${green(pkgJSON.name)} will be its ${red('first major release')}.`));
+-    log(yellow(`If you are unsure if this is correct, contact the package's maintainers ${red("before committing this changeset")}.`));
+-    let shouldReleaseFirstMajor = await askConfirm(bold(`Are you sure you want to release the ${red("first major version")} of ${pkgJSON.name}?`));
++    log(
++      yellow(
++        `If you are unsure if this is correct, contact the package's maintainers ${red(
++          "before committing this changeset"
++        )}.`
++      )
++    );
++    let shouldReleaseFirstMajor = await askConfirm(
++      bold(
++        `Are you sure you want to release the ${red(
++          "first major version"
++        )} of ${pkgJSON.name}?`
++      )
++    );
+     return shouldReleaseFirstMajor;
+   }
+ 
+@@ -212,32 +273,42 @@ async function confirmMajorRelease(pkgJSON) {
+ 
+ async function getPackagesToRelease(changedPackages, allPackages) {
+   function askInitialReleaseQuestion(defaultChoiceList) {
+-    return askCheckboxPlus( // TODO: Make this wording better
+-    // TODO: take objects and be fancy with matching
+-    `Which packages would you like to include?`, defaultChoiceList, x => {
+-      // this removes changed packages and unchanged packages from the list
+-      // of packages shown after selection
+-      if (Array.isArray(x)) {
+-        return x.filter(x => x !== "changed packages" && x !== "unchanged packages").map(x => cyan(x)).join(", ");
+-      }
++    return askCheckboxPlus(
++      // TODO: Make this wording better
++      // TODO: take objects and be fancy with matching
++      `Which packages would you like to include?`,
++      defaultChoiceList,
++      (x) => {
++        // this removes changed packages and unchanged packages from the list
++        // of packages shown after selection
++        if (Array.isArray(x)) {
++          return x
++            .filter(
++              (x) => x !== "changed packages" && x !== "unchanged packages"
++            )
++            .map((x) => cyan(x))
++            .join(", ");
++        }
+ 
+-      return x;
+-    });
++        return x;
++      }
++    );
+   }
+ 
+   if (allPackages.length > 1) {
+-    const unchangedPackagesNames = allPackages.map(({
+-      packageJson
+-    }) => packageJson.name).filter(name => !changedPackages.includes(name));
+-    const defaultChoiceList = [{
+-      name: "changed packages",
+-      choices: changedPackages
+-    }, {
+-      name: "unchanged packages",
+-      choices: unchangedPackagesNames
+-    }].filter(({
+-      choices
+-    }) => choices.length !== 0);
++    const unchangedPackagesNames = allPackages
++      .map(({ packageJson }) => packageJson.name)
++      .filter((name) => !changedPackages.includes(name));
++    const defaultChoiceList = [
++      {
++        name: "changed packages",
++        choices: changedPackages,
++      },
++      {
++        name: "unchanged packages",
++        choices: unchangedPackagesNames,
++      },
++    ].filter(({ choices }) => choices.length !== 0);
+     let packagesToRelease = await askInitialReleaseQuestion(defaultChoiceList);
+ 
+     if (packagesToRelease.length === 0) {
+@@ -248,16 +319,19 @@ async function getPackagesToRelease(changedPackages, allPackages) {
+       } while (packagesToRelease.length === 0);
+     }
+ 
+-    return packagesToRelease.filter(pkgName => pkgName !== "changed packages" && pkgName !== "unchanged packages");
++    return packagesToRelease.filter(
++      (pkgName) =>
++        pkgName !== "changed packages" && pkgName !== "unchanged packages"
++    );
+   }
+ 
+   return [allPackages[0].packageJson.name];
+ }
+ 
+ function getPkgJsonsByName(packages) {
+-  return new Map(packages.map(({
+-    packageJson
+-  }) => [packageJson.name, packageJson]));
++  return new Map(
++    packages.map(({ packageJson }) => [packageJson.name, packageJson])
++  );
+ }
+ 
+ function formatPkgNameAndVersion(pkgName, version) {
+@@ -268,26 +342,43 @@ async function createChangeset(changedPackages, allPackages) {
+   const releases = [];
+ 
+   if (allPackages.length > 1) {
+-    const packagesToRelease = await getPackagesToRelease(changedPackages, allPackages);
++    const packagesToRelease = await getPackagesToRelease(
++      changedPackages,
++      allPackages
++    );
+     let pkgJsonsByName = getPkgJsonsByName(allPackages);
+     let pkgsLeftToGetBumpTypeFor = new Set(packagesToRelease);
+-    let pkgsThatShouldBeMajorBumped = (await askCheckboxPlus(bold(`Which packages should have a ${red("major")} bump?`), [{
+-      name: "all packages",
+-      choices: packagesToRelease.map(pkgName => {
+-        return {
+-          name: pkgName,
+-          message: formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version)
+-        };
+-      })
+-    }], x => {
+-      // this removes changed packages and unchanged packages from the list
+-      // of packages shown after selection
+-      if (Array.isArray(x)) {
+-        return x.filter(x => x !== "all packages").map(x => cyan(x)).join(", ");
+-      }
++    let pkgsThatShouldBeMajorBumped = (
++      await askCheckboxPlus(
++        bold(`Which packages should have a ${red("major")} bump?`),
++        [
++          {
++            name: "all packages",
++            choices: packagesToRelease.map((pkgName) => {
++              return {
++                name: pkgName,
++                message: formatPkgNameAndVersion(
++                  pkgName,
++                  pkgJsonsByName.get(pkgName).version
++                ),
++              };
++            }),
++          },
++        ],
++        (x) => {
++          // this removes changed packages and unchanged packages from the list
++          // of packages shown after selection
++          if (Array.isArray(x)) {
++            return x
++              .filter((x) => x !== "all packages")
++              .map((x) => cyan(x))
++              .join(", ");
++          }
+ 
+-      return x;
+-    })).filter(x => x !== "all packages");
++          return x;
++        }
++      )
++    ).filter((x) => x !== "all packages");
+ 
+     for (const pkgName of pkgsThatShouldBeMajorBumped) {
+       // for packages that are under v1, we want to make sure major releases are intended,
+@@ -300,55 +391,76 @@ async function createChangeset(changedPackages, allPackages) {
+         pkgsLeftToGetBumpTypeFor.delete(pkgName);
+         releases.push({
+           name: pkgName,
+-          type: "major"
++          type: "major",
+         });
+       }
+     }
+ 
+     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
+-      let pkgsThatShouldBeMinorBumped = (await askCheckboxPlus(bold(`Which packages should have a ${green("minor")} bump?`), [{
+-        name: "all packages",
+-        choices: [...pkgsLeftToGetBumpTypeFor].map(pkgName => {
+-          return {
+-            name: pkgName,
+-            message: formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version)
+-          };
+-        })
+-      }], x => {
+-        // this removes changed packages and unchanged packages from the list
+-        // of packages shown after selection
+-        if (Array.isArray(x)) {
+-          return x.filter(x => x !== "all packages").map(x => cyan(x)).join(", ");
+-        }
++      let pkgsThatShouldBeMinorBumped = (
++        await askCheckboxPlus(
++          bold(`Which packages should have a ${green("minor")} bump?`),
++          [
++            {
++              name: "all packages",
++              choices: [...pkgsLeftToGetBumpTypeFor].map((pkgName) => {
++                return {
++                  name: pkgName,
++                  message: formatPkgNameAndVersion(
++                    pkgName,
++                    pkgJsonsByName.get(pkgName).version
++                  ),
++                };
++              }),
++            },
++          ],
++          (x) => {
++            // this removes changed packages and unchanged packages from the list
++            // of packages shown after selection
++            if (Array.isArray(x)) {
++              return x
++                .filter((x) => x !== "all packages")
++                .map((x) => cyan(x))
++                .join(", ");
++            }
+ 
+-        return x;
+-      })).filter(x => x !== "all packages");
++            return x;
++          }
++        )
++      ).filter((x) => x !== "all packages");
+ 
+       for (const pkgName of pkgsThatShouldBeMinorBumped) {
+         pkgsLeftToGetBumpTypeFor.delete(pkgName);
+         releases.push({
+           name: pkgName,
+-          type: "minor"
++          type: "minor",
+         });
+       }
+     }
+ 
+     if (pkgsLeftToGetBumpTypeFor.size !== 0) {
+       log(`The following packages will be ${blue("patch")} bumped:`);
+-      pkgsLeftToGetBumpTypeFor.forEach(pkgName => {
+-        log(formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version));
++      pkgsLeftToGetBumpTypeFor.forEach((pkgName) => {
++        log(
++          formatPkgNameAndVersion(pkgName, pkgJsonsByName.get(pkgName).version)
++        );
+       });
+ 
+       for (const pkgName of pkgsLeftToGetBumpTypeFor) {
+         releases.push({
+           name: pkgName,
+-          type: "patch"
++          type: "patch",
+         });
+       }
+     }
+   } else {
+     let pkg = allPackages[0];
+-    let type = await askList(`What kind of change is this for ${green(pkg.packageJson.name)}? (current version is ${pkg.packageJson.version})`, ["patch", "minor", "major"]);
++    let type = await askList(
++      `What kind of change is this for ${green(
++        pkg.packageJson.name
++      )}? (current version is ${pkg.packageJson.version})`,
++      ["patch", "minor", "major"]
++    );
+ 
+     if (type === "major") {
+       let shouldReleaseAsMajor = await confirmMajorRelease(pkg.packageJson);
+@@ -360,61 +472,76 @@ async function createChangeset(changedPackages, allPackages) {
+ 
+     releases.push({
+       name: pkg.packageJson.name,
+-      type
++      type,
+     });
+   }
+ 
+-  log("Please enter a summary for this change (this will be in the changelogs).");
++  log(
++    "Please enter a summary for this change (this will be in the changelogs)."
++  );
+   log(chalk.gray("  (submit empty line to open external editor)"));
+   let summary = await askQuestion("Summary");
+ 
+   if (summary.length === 0) {
+     try {
+-      summary = askQuestionWithEditor("\n\n# Please enter a summary for your changes.\n# An empty message aborts the editor.");
++      summary = askQuestionWithEditor(
++        "\n\n# Please enter a summary for your changes.\n# An empty message aborts the editor."
++      );
+ 
+       if (summary.length > 0) {
+         return {
+           confirmed: true,
+           summary,
+-          releases
++          releases,
+         };
+       }
+     } catch (err) {
+-      log("An error happened using external editor. Please type your summary here:");
++      log(
++        "An error happened using external editor. Please type your summary here:"
++      );
+     }
+ 
+     summary = await askQuestion("");
+ 
+     while (summary.length === 0) {
+-      summary = await askQuestion("\n\n# A summary is required for the changelog! 😪");
++      summary = await askQuestion(
++        "\n\n# A summary is required for the changelog! 😪"
++      );
+     }
+   }
+ 
+   return {
+     confirmed: false,
+     summary,
+-    releases
++    releases,
+   };
+ }
+ 
+ function printConfirmationMessage(changeset, repoHasMultiplePackages) {
+   function getReleasesOfType(type) {
+-    return changeset.releases.filter(release => release.type === type).map(release => release.name);
++    return changeset.releases
++      .filter((release) => release.type === type)
++      .map((release) => release.name);
+   }
+ 
+   log("\n=== Summary of changesets ===");
+   const majorReleases = getReleasesOfType("major");
+   const minorReleases = getReleasesOfType("minor");
+   const patchReleases = getReleasesOfType("patch");
+-  if (majorReleases.length > 0) log(`${chalk.bold.green("major")}:  ${majorReleases.join(", ")}`);
+-  if (minorReleases.length > 0) log(`${chalk.bold.green("minor")}:  ${minorReleases.join(", ")}`);
+-  if (patchReleases.length > 0) log(`${chalk.bold.green("patch")}:  ${patchReleases.join(", ")}`);
++  if (majorReleases.length > 0)
++    log(`${chalk.bold.green("major")}:  ${majorReleases.join(", ")}`);
++  if (minorReleases.length > 0)
++    log(`${chalk.bold.green("minor")}:  ${minorReleases.join(", ")}`);
++  if (patchReleases.length > 0)
++    log(`${chalk.bold.green("patch")}:  ${patchReleases.join(", ")}`);
+   log("");
+ 
+   if (repoHasMultiplePackages) {
+     const message = outdent`
+       Note: All dependents of these packages that will be incompatible with
+-      the new version will be ${chalk.redBright("patch bumped")} when this changeset is applied.
++      the new version will be ${chalk.redBright(
++        "patch bumped"
++      )} when this changeset is applied.
+     `;
+     log(message + "\n");
+   }
+@@ -435,17 +562,18 @@ function isListablePackage(config, packageJson) {
+   return hasVersionField;
+ }
+ 
+-async function add(cwd, {
+-  empty,
+-  open
+-}, config) {
++async function add(cwd, { empty, open }, config) {
+   const packages = await getPackages(cwd);
+ 
+   if (packages.packages.length === 0) {
+-    throw new Error(`No packages found. You might have ${packages.tool} workspaces configured but no packages yet?`);
++    throw new Error(
++      `No packages found. You might have ${packages.tool} workspaces configured but no packages yet?`
++    );
+   }
+ 
+-  const listablePackages = packages.packages.filter(pkg => isListablePackage(config, pkg.packageJson));
++  const listablePackages = packages.packages.filter((pkg) =>
++    isListablePackage(config, pkg.packageJson)
++  );
+   const changesetBase = path.resolve(cwd, ".changeset");
+   let newChangeset;
+ 
+@@ -453,48 +581,67 @@ async function add(cwd, {
+     newChangeset = {
+       confirmed: true,
+       releases: [],
+-      summary: ``
++      summary: ``,
+     };
+   } else {
+     const changedPackages = await git.getChangedPackagesSinceRef({
+       cwd,
+       ref: config.baseBranch,
+-      changedFilePatterns: config.changedFilePatterns
++      changedFilePatterns: config.changedFilePatterns,
+     });
+-    const changedPackagesName = changedPackages.filter(pkg => isListablePackage(config, pkg.packageJson)).map(pkg => pkg.packageJson.name);
++    const changedPackagesName = changedPackages
++      .filter((pkg) => isListablePackage(config, pkg.packageJson))
++      .map((pkg) => pkg.packageJson.name);
+     newChangeset = await createChangeset(changedPackagesName, listablePackages);
+     printConfirmationMessage(newChangeset, listablePackages.length > 1);
+ 
+     if (!newChangeset.confirmed) {
+-      newChangeset = _objectSpread(_objectSpread({}, newChangeset), {}, {
+-        confirmed: await askConfirm("Is this your desired changeset?")
+-      });
++      newChangeset = _objectSpread(
++        _objectSpread({}, newChangeset),
++        {},
++        {
++          confirmed: await askConfirm("Is this your desired changeset?"),
++        }
++      );
+     }
+   }
+ 
+   if (newChangeset.confirmed) {
+     const changesetID = await writeChangeset(newChangeset, cwd);
+-    const [{
+-      getAddMessage
+-    }, commitOpts] = getCommitFunctions(config.commit, cwd);
++    const [{ getAddMessage }, commitOpts] = getCommitFunctions(
++      config.commit,
++      cwd
++    );
+ 
+     if (getAddMessage) {
+       await git.add(path.resolve(changesetBase, `${changesetID}.md`), cwd);
+       await git.commit(await getAddMessage(newChangeset, commitOpts), cwd);
+       log(chalk.green(`${empty ? "Empty " : ""}Changeset added and committed`));
+     } else {
+-      log(chalk.green(`${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`));
++      log(
++        chalk.green(
++          `${empty ? "Empty " : ""}Changeset added! - you can now commit it\n`
++        )
++      );
+     }
+ 
+-    let hasMajorChange = [...newChangeset.releases].find(c => c.type === "major");
++    let hasMajorChange = [...newChangeset.releases].find(
++      (c) => c.type === "major"
++    );
+ 
+     if (hasMajorChange) {
+-      warn("This Changeset includes a major change and we STRONGLY recommend adding more information to the changeset:");
++      warn(
++        "This Changeset includes a major change and we STRONGLY recommend adding more information to the changeset:"
++      );
+       warn("WHAT the breaking change is");
+       warn("WHY the change was made");
+       warn("HOW a consumer should update their code");
+     } else {
+-      log(chalk.green("If you want to modify or expand on the changeset summary, you can find it here"));
++      log(
++        chalk.green(
++          "If you want to modify or expand on the changeset summary, you can find it here"
++        )
++      );
+     }
+ 
+     const changesetPath = path.resolve(changesetBase, `${changesetID}.md`);
+@@ -504,10 +651,14 @@ async function add(cwd, {
+       // this is really a hack to reuse the logic embedded in `external-editor` related to determining the editor
+       const externalEditor = new ExternalEditor();
+       externalEditor.cleanup();
+-      spawn(externalEditor.editor.bin, externalEditor.editor.args.concat([changesetPath]), {
+-        detached: true,
+-        stdio: "inherit"
+-      });
++      spawn(
++        externalEditor.editor.bin,
++        externalEditor.editor.args.concat([changesetPath]),
++        {
++          detached: true,
++          stdio: "inherit",
++        }
++      );
+     }
+   }
+ }
+@@ -515,36 +666,53 @@ async function add(cwd, {
+ // folder, and tidy up the subfolders
+ // THIS SHOULD BE REMOVED WHEN SUPPORT FOR CHANGESETS FROM V1 IS DROPPED
+ 
+-const removeEmptyFolders = async folderPath => {
++const removeEmptyFolders = async (folderPath) => {
+   const dirContents = fs.readdirSync(folderPath);
+-  return Promise.all(dirContents.map(async contentPath => {
+-    const singleChangesetPath = path.resolve(folderPath, contentPath);
++  return Promise.all(
++    dirContents.map(async (contentPath) => {
++      const singleChangesetPath = path.resolve(folderPath, contentPath);
+ 
+-    try {
+-      if ((await fs.readdir(singleChangesetPath)).length < 1) {
+-        await fs.rmdir(singleChangesetPath);
+-      }
+-    } catch (err) {
+-      if (err.code !== "ENOTDIR") {
+-        throw err;
++      try {
++        if ((await fs.readdir(singleChangesetPath)).length < 1) {
++          await fs.rmdir(singleChangesetPath);
++        }
++      } catch (err) {
++        if (err.code !== "ENOTDIR") {
++          throw err;
++        }
+       }
+-    }
+-  }));
++    })
++  );
+ };
+ 
+-let importantSeparator$1 = chalk.red("===============================IMPORTANT!===============================");
+-let importantEnd$1 = chalk.red("----------------------------------------------------------------------");
++let importantSeparator$1 = chalk.red(
++  "===============================IMPORTANT!==============================="
++);
++let importantEnd$1 = chalk.red(
++  "----------------------------------------------------------------------"
++);
+ async function version(cwd, options, config) {
+   var _config$snapshot$prer;
+ 
+-  const releaseConfig = _objectSpread(_objectSpread({}, config), {}, {
+-    // Disable committing when in snapshot mode
+-    commit: options.snapshot ? false : config.commit
+-  });
+-
+-  const [changesets, preState] = await Promise.all([readChangesets(cwd), readPreState(cwd), removeEmptyFolders(path.resolve(cwd, ".changeset"))]);
+-
+-  if ((preState === null || preState === void 0 ? void 0 : preState.mode) === "pre") {
++  const releaseConfig = _objectSpread(
++    _objectSpread({}, config),
++    {},
++    {
++      // Disable committing when in snapshot mode
++      commit: options.snapshot ? false : config.commit,
++    }
++  );
++
++  const [changesets, preState] = await Promise.all([
++    readChangesets(cwd),
++    readPreState(cwd),
++    removeEmptyFolders(path.resolve(cwd, ".changeset")),
++  ]);
++
++  if (
++    (preState === null || preState === void 0 ? void 0 : preState.mode) ===
++    "pre"
++  ) {
+     warn(importantSeparator$1);
+ 
+     if (options.snapshot !== undefined) {
+@@ -553,51 +721,81 @@ async function version(cwd, options, config) {
+       throw new ExitError(1);
+     } else {
+       warn("You are in prerelease mode");
+-      warn("If you meant to do a normal release you should revert these changes and run `changeset pre exit`");
++      warn(
++        "If you meant to do a normal release you should revert these changes and run `changeset pre exit`"
++      );
+       warn("You can then run `changeset version` again to do a normal release");
+     }
+ 
+     warn(importantEnd$1);
+   }
+ 
+-  if (changesets.length === 0 && (preState === undefined || preState.mode !== "exit")) {
++  if (
++    changesets.length === 0 &&
++    (preState === undefined || preState.mode !== "exit")
++  ) {
+     warn("No unreleased changesets found, exiting.");
+     return;
+   }
+ 
+   let packages = await getPackages(cwd);
+-  let releasePlan = assembleReleasePlan(changesets, packages, releaseConfig, preState, options.snapshot ? {
+-    tag: options.snapshot === true ? undefined : options.snapshot,
+-    commit: (_config$snapshot$prer = config.snapshot.prereleaseTemplate) !== null && _config$snapshot$prer !== void 0 && _config$snapshot$prer.includes("{commit}") ? await getCurrentCommitId({
+-      cwd
+-    }) : undefined
+-  } : undefined);
+-  let [...touchedFiles] = await applyReleasePlan(releasePlan, packages, releaseConfig, options.snapshot);
+-  const [{
+-    getVersionMessage
+-  }, commitOpts] = getCommitFunctions(releaseConfig.commit, cwd);
++  let releasePlan = assembleReleasePlan(
++    changesets,
++    packages,
++    releaseConfig,
++    preState,
++    options.snapshot
++      ? {
++          tag: options.snapshot === true ? undefined : options.snapshot,
++          commit:
++            (_config$snapshot$prer = config.snapshot.prereleaseTemplate) !==
++              null &&
++            _config$snapshot$prer !== void 0 &&
++            _config$snapshot$prer.includes("{commit}")
++              ? await getCurrentCommitId({
++                  cwd,
++                })
++              : undefined,
++        }
++      : undefined
++  );
++  let [...touchedFiles] = await applyReleasePlan(
++    releasePlan,
++    packages,
++    releaseConfig,
++    options.snapshot
++  );
++  const [{ getVersionMessage }, commitOpts] = getCommitFunctions(
++    releaseConfig.commit,
++    cwd
++  );
+ 
+   if (getVersionMessage) {
+     let touchedFile; // Note, git gets angry if you try and have two git actions running at once
+     // So we need to be careful that these iterations are properly sequential
+ 
+-    while (touchedFile = touchedFiles.shift()) {
++    while ((touchedFile = touchedFiles.shift())) {
+       await git.add(path.relative(cwd, touchedFile), cwd);
+     }
+ 
+-    const commit = await git.commit(await getVersionMessage(releasePlan, commitOpts), cwd);
++    const commit = await git.commit(
++      await getVersionMessage(releasePlan, commitOpts),
++      cwd
++    );
+ 
+     if (!commit) {
+       error("Changesets ran into trouble committing your files");
+     } else {
+-      log("All files have been updated and committed. You're ready to publish!");
++      log(
++        "All files have been updated and committed. You're ready to publish!"
++      );
+     }
+   } else {
+     log("All files have been updated. Review them and commit at your leisure");
+   }
+ }
+ 
+-const getLastJsonObjectFromString = str => {
++const getLastJsonObjectFromString = (str) => {
+   str = str.replace(/[^}]*$/, "");
+ 
+   while (str) {
+@@ -632,30 +830,47 @@ function jsonParse(input) {
+ function getCorrectRegistry(packageJson) {
+   var _packageJson$publishC, _packageJson$publishC2;
+ 
+-  const registry = (_packageJson$publishC = packageJson === null || packageJson === void 0 ? void 0 : (_packageJson$publishC2 = packageJson.publishConfig) === null || _packageJson$publishC2 === void 0 ? void 0 : _packageJson$publishC2.registry) !== null && _packageJson$publishC !== void 0 ? _packageJson$publishC : process.env.npm_config_registry;
+-  return !registry || registry === "https://registry.yarnpkg.com" ? "https://registry.npmjs.org" : registry;
++  const registry =
++    (_packageJson$publishC =
++      packageJson === null || packageJson === void 0
++        ? void 0
++        : (_packageJson$publishC2 = packageJson.publishConfig) === null ||
++          _packageJson$publishC2 === void 0
++        ? void 0
++        : _packageJson$publishC2.registry) !== null &&
++    _packageJson$publishC !== void 0
++      ? _packageJson$publishC
++      : process.env.npm_config_registry;
++  return !registry || registry === "https://registry.yarnpkg.com"
++    ? "https://registry.npmjs.org"
++    : registry;
+ }
+ 
+ async function getPublishTool(cwd) {
+   const pm = await preferredPM(cwd);
+-  if (!pm || pm.name !== "pnpm") return {
+-    name: "npm"
+-  };
++  if (!pm || pm.name !== "pnpm")
++    return {
++      name: "npm",
++    };
+ 
+   try {
+     let result = await spawn$1("pnpm", ["--version"], {
+-      cwd
++      cwd,
+     });
+     let version = result.stdout.toString().trim();
+     let parsed = semverParse(version);
+     return {
+       name: "pnpm",
+-      shouldAddNoGitChecks: (parsed === null || parsed === void 0 ? void 0 : parsed.major) === undefined ? false : parsed.major >= 5
++      shouldAddNoGitChecks:
++        (parsed === null || parsed === void 0 ? void 0 : parsed.major) ===
++        undefined
++          ? false
++          : parsed.major >= 5,
+     };
+   } catch (e) {
+     return {
+       name: "pnpm",
+-      shouldAddNoGitChecks: false
++      shouldAddNoGitChecks: false,
+     };
+   }
+ }
+@@ -664,14 +879,17 @@ async function getTokenIsRequired() {
+   // Due to a super annoying issue in yarn, we have to manually override this env variable
+   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+   const envOverride = {
+-    npm_config_registry: getCorrectRegistry()
++    npm_config_registry: getCorrectRegistry(),
+   };
+   let result = await spawn$1("npm", ["profile", "get", "--json"], {
+-    env: Object.assign({}, process.env, envOverride)
++    env: Object.assign({}, process.env, envOverride),
+   });
+ 
+   if (result.code !== 0) {
+-    error("error while checking if token is required", result.stderr.toString().trim() || result.stdout.toString().trim());
++    error(
++      "error while checking if token is required",
++      result.stderr.toString().trim() || result.stdout.toString().trim()
++    );
+     return false;
+   }
+ 
+@@ -692,14 +910,20 @@ function getPackageInfo(packageJson) {
+     // as they will always give a 404, which will tell `publish` to always try to publish.
+     // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+ 
+-    let result = await spawn$1("npm", ["info", packageJson.name, "--registry", getCorrectRegistry(packageJson), "--json"]); // Github package registry returns empty string when calling npm info
++    let result = await spawn$1("npm", [
++      "info",
++      packageJson.name,
++      "--registry",
++      getCorrectRegistry(packageJson),
++      "--json",
++    ]); // Github package registry returns empty string when calling npm info
+     // for a non-existent package instead of a E404
+ 
+     if (result.stdout.toString() === "") {
+       return {
+         error: {
+-          code: "E404"
+-        }
++          code: "E404",
++        },
+       };
+     }
+ 
+@@ -711,16 +935,24 @@ async function infoAllow404(packageJson) {
+ 
+   let pkgInfo = await getPackageInfo(packageJson);
+ 
+-  if (((_pkgInfo$error = pkgInfo.error) === null || _pkgInfo$error === void 0 ? void 0 : _pkgInfo$error.code) === "E404") {
++  if (
++    ((_pkgInfo$error = pkgInfo.error) === null || _pkgInfo$error === void 0
++      ? void 0
++      : _pkgInfo$error.code) === "E404"
++  ) {
+     warn(`Received 404 for npm info ${chalk.cyan(`"${packageJson.name}"`)}`);
+     return {
+       published: false,
+-      pkgInfo: {}
++      pkgInfo: {},
+     };
+   }
+ 
+   if (pkgInfo.error) {
+-    error(`Received an unknown error code: ${pkgInfo.error.code} for npm info ${chalk.cyan(`"${packageJson.name}"`)}`);
++    error(
++      `Received an unknown error code: ${
++        pkgInfo.error.code
++      } for npm info ${chalk.cyan(`"${packageJson.name}"`)}`
++    );
+     error(pkgInfo.error.summary);
+     if (pkgInfo.error.detail) error(pkgInfo.error.detail);
+     throw new ExitError(1);
+@@ -728,20 +960,23 @@ async function infoAllow404(packageJson) {
+ 
+   return {
+     published: true,
+-    pkgInfo
++    pkgInfo,
+   };
+ }
+ let otpAskLimit = pLimit(1);
+ 
+-let askForOtpCode = twoFactorState => otpAskLimit(async () => {
+-  if (twoFactorState.token !== null) return twoFactorState.token;
+-  info("This operation requires a one-time password from your authenticator.");
+-  let val = await askQuestion("Enter one-time password:");
+-  twoFactorState.token = val;
+-  return val;
+-});
++let askForOtpCode = (twoFactorState) =>
++  otpAskLimit(async () => {
++    if (twoFactorState.token !== null) return twoFactorState.token;
++    info(
++      "This operation requires a one-time password from your authenticator."
++    );
++    let val = await askQuestion("Enter one-time password:");
++    twoFactorState.token = val;
++    return val;
++  });
+ 
+-let getOtpCode = async twoFactorState => {
++let getOtpCode = async (twoFactorState) => {
+   if (twoFactorState.token !== null) {
+     return twoFactorState.token;
+   }
+@@ -765,20 +1000,28 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+   } // Due to a super annoying issue in yarn, we have to manually override this env variable
+   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
+ 
++  // add provenance flag when publishing with NPM
++  // @see https://github.com/changesets/changesets/issues/1152
++  if (publishTool.name === "npm") {
++    publishFlags.push("--provenance");
++  }
+ 
+   const envOverride = {
+-    npm_config_registry: getCorrectRegistry()
++    npm_config_registry: getCorrectRegistry(),
+   };
+-  let {
+-    code,
+-    stdout,
+-    stderr
+-  } = publishTool.name === "pnpm" ? await spawn$1("pnpm", ["publish", "--json", ...publishFlags], {
+-    env: Object.assign({}, process.env, envOverride),
+-    cwd: opts.cwd
+-  }) : await spawn$1(publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
+-    env: Object.assign({}, process.env, envOverride)
+-  });
++  let { code, stdout, stderr } =
++    publishTool.name === "pnpm"
++      ? await spawn$1("pnpm", ["publish", "--json", ...publishFlags], {
++          env: Object.assign({}, process.env, envOverride),
++          cwd: opts.cwd,
++        })
++      : await spawn$1(
++          publishTool.name,
++          ["publish", opts.publishDir, "--json", ...publishFlags],
++          {
++            env: Object.assign({}, process.env, envOverride),
++          }
++        );
+ 
+   if (code !== 0) {
+     // NPM's --json output is included alongside the `prepublish` and `postpublish` output in terminal
+@@ -786,39 +1029,51 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+     // - output of those lifecycle scripts can contain JSON
+     // - npm7 has switched to printing `--json` errors to stderr (https://github.com/npm/cli/commit/1dbf0f9bb26ba70f4c6d0a807701d7652c31d7d4)
+     // Note that the `--json` output is always printed at the end so this should work
+-    let json = getLastJsonObjectFromString(stderr.toString()) || getLastJsonObjectFromString(stdout.toString());
++    let json =
++      getLastJsonObjectFromString(stderr.toString()) ||
++      getLastJsonObjectFromString(stdout.toString());
+ 
+     if (json !== null && json !== void 0 && json.error) {
+       // The first case is no 2fa provided, the second is when the 2fa is wrong (timeout or wrong words)
+-      if ((json.error.code === "EOTP" || json.error.code === "E401" && json.error.detail.includes("--otp=<code>")) && !isCI) {
++      if (
++        (json.error.code === "EOTP" ||
++          (json.error.code === "E401" &&
++            json.error.detail.includes("--otp=<code>"))) &&
++        !isCI
++      ) {
+         if (twoFactorState.token !== null) {
+           // the current otp code must be invalid since it errored
+           twoFactorState.token = null;
+         } // just in case this isn't already true
+ 
+-
+         twoFactorState.isRequired = Promise.resolve(true);
+         return internalPublish(pkgName, opts, twoFactorState);
+       }
+ 
+-      error(`an error occurred while publishing ${pkgName}: ${json.error.code}`, json.error.summary, json.error.detail ? "\n" + json.error.detail : "");
++      error(
++        `an error occurred while publishing ${pkgName}: ${json.error.code}`,
++        json.error.summary,
++        json.error.detail ? "\n" + json.error.detail : ""
++      );
+     }
+ 
+     error(stderr.toString() || stdout.toString());
+     return {
+-      published: false
++      published: false,
+     };
+   }
+ 
+   return {
+-    published: true
++    published: true,
+   };
+ }
+ 
+ function publish(pkgName, opts, twoFactorState) {
+   // If there are many packages to be published, it's better to limit the
+   // concurrency to avoid unwanted errors, for example from npm.
+-  return npmRequestLimit(() => npmPublishLimit(() => internalPublish(pkgName, opts, twoFactorState)));
++  return npmRequestLimit(() =>
++    npmPublishLimit(() => internalPublish(pkgName, opts, twoFactorState))
++  );
+ }
+ 
+ function getReleaseTag(pkgInfo, preState, tag) {
+@@ -831,47 +1086,53 @@ function getReleaseTag(pkgInfo, preState, tag) {
+   return "latest";
+ }
+ 
+-const isCustomRegistry = registry => !!registry && registry !== "https://registry.npmjs.org" && registry !== "https://registry.yarnpkg.com";
++const isCustomRegistry = (registry) =>
++  !!registry &&
++  registry !== "https://registry.npmjs.org" &&
++  registry !== "https://registry.yarnpkg.com";
+ 
+-const getTwoFactorState = ({
+-  otp,
+-  publicPackages
+-}) => {
++const getTwoFactorState = ({ otp, publicPackages }) => {
+   if (otp) {
+     return {
+       token: otp,
+-      isRequired: Promise.resolve(true)
++      isRequired: Promise.resolve(true),
+     };
+   }
+ 
+-  if (isCI || publicPackages.some(pkg => {
+-    var _pkg$packageJson$publ;
+-
+-    return isCustomRegistry((_pkg$packageJson$publ = pkg.packageJson.publishConfig) === null || _pkg$packageJson$publ === void 0 ? void 0 : _pkg$packageJson$publ.registry);
+-  }) || isCustomRegistry(process.env.npm_config_registry)) {
++  if (
++    isCI ||
++    publicPackages.some((pkg) => {
++      var _pkg$packageJson$publ;
++
++      return isCustomRegistry(
++        (_pkg$packageJson$publ = pkg.packageJson.publishConfig) === null ||
++          _pkg$packageJson$publ === void 0
++          ? void 0
++          : _pkg$packageJson$publ.registry
++      );
++    }) ||
++    isCustomRegistry(process.env.npm_config_registry)
++  ) {
+     return {
+       token: null,
+-      isRequired: Promise.resolve(false)
++      isRequired: Promise.resolve(false),
+     };
+   }
+ 
+   return {
+     token: null,
+     // note: we're not awaiting this here, we want this request to happen in parallel with getUnpublishedPackages
+-    isRequired: getTokenIsRequired()
++    isRequired: getTokenIsRequired(),
+   };
+ };
+ 
+-async function publishPackages({
+-  packages,
+-  access,
+-  otp,
+-  preState,
+-  tag
+-}) {
+-  const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]));
+-  const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
+-  const unpublishedPackagesInfo = await getUnpublishedPackages(publicPackages, preState);
++async function publishPackages({ packages, access, otp, preState, tag }) {
++  const packagesByName = new Map(packages.map((x) => [x.packageJson.name, x]));
++  const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
++  const unpublishedPackagesInfo = await getUnpublishedPackages(
++    publicPackages,
++    preState
++  );
+ 
+   if (unpublishedPackagesInfo.length === 0) {
+     return [];
+@@ -879,78 +1140,105 @@ async function publishPackages({
+ 
+   const twoFactorState = getTwoFactorState({
+     otp,
+-    publicPackages
++    publicPackages,
+   });
+-  return Promise.all(unpublishedPackagesInfo.map(pkgInfo => {
+-    let pkg = packagesByName.get(pkgInfo.name);
+-    return publishAPackage(pkg, access, twoFactorState, getReleaseTag(pkgInfo, preState, tag));
+-  }));
++  return Promise.all(
++    unpublishedPackagesInfo.map((pkgInfo) => {
++      let pkg = packagesByName.get(pkgInfo.name);
++      return publishAPackage(
++        pkg,
++        access,
++        twoFactorState,
++        getReleaseTag(pkgInfo, preState, tag)
++      );
++    })
++  );
+ }
+ 
+ async function publishAPackage(pkg, access, twoFactorState, tag) {
+-  const {
++  const { name, version, publishConfig } = pkg.packageJson;
++  info(
++    `Publishing ${chalk.cyan(`"${name}"`)} at ${chalk.green(`"${version}"`)}`
++  );
++  const publishConfirmation = await publish(
+     name,
+-    version,
+-    publishConfig
+-  } = pkg.packageJson;
+-  info(`Publishing ${chalk.cyan(`"${name}"`)} at ${chalk.green(`"${version}"`)}`);
+-  const publishConfirmation = await publish(name, {
+-    cwd: pkg.dir,
+-    publishDir: publishConfig !== null && publishConfig !== void 0 && publishConfig.directory ? join(pkg.dir, publishConfig.directory) : pkg.dir,
+-    access: (publishConfig === null || publishConfig === void 0 ? void 0 : publishConfig.access) || access,
+-    tag
+-  }, twoFactorState);
++    {
++      cwd: pkg.dir,
++      publishDir:
++        publishConfig !== null &&
++        publishConfig !== void 0 &&
++        publishConfig.directory
++          ? join(pkg.dir, publishConfig.directory)
++          : pkg.dir,
++      access:
++        (publishConfig === null || publishConfig === void 0
++          ? void 0
++          : publishConfig.access) || access,
++      tag,
++    },
++    twoFactorState
++  );
+   return {
+     name,
+     newVersion: version,
+-    published: publishConfirmation.published
++    published: publishConfirmation.published,
+   };
+ }
+ 
+ async function getUnpublishedPackages(packages, preState) {
+-  const results = await Promise.all(packages.map(async ({
+-    packageJson
+-  }) => {
+-    const response = await infoAllow404(packageJson);
+-    let publishedState = "never";
+-
+-    if (response.published) {
+-      publishedState = "published";
+-
+-      if (preState !== undefined) {
+-        if (response.pkgInfo.versions && response.pkgInfo.versions.every(version => semverParse(version).prerelease[0] === preState.tag)) {
+-          publishedState = "only-pre";
++  const results = await Promise.all(
++    packages.map(async ({ packageJson }) => {
++      const response = await infoAllow404(packageJson);
++      let publishedState = "never";
++
++      if (response.published) {
++        publishedState = "published";
++
++        if (preState !== undefined) {
++          if (
++            response.pkgInfo.versions &&
++            response.pkgInfo.versions.every(
++              (version) => semverParse(version).prerelease[0] === preState.tag
++            )
++          ) {
++            publishedState = "only-pre";
++          }
+         }
+       }
+-    }
+ 
+-    return {
+-      name: packageJson.name,
+-      localVersion: packageJson.version,
+-      publishedState,
+-      publishedVersions: response.pkgInfo.versions || []
+-    };
+-  }));
++      return {
++        name: packageJson.name,
++        localVersion: packageJson.version,
++        publishedState,
++        publishedVersions: response.pkgInfo.versions || [],
++      };
++    })
++  );
+   const packagesToPublish = [];
+ 
+   for (const pkgInfo of results) {
+-    const {
+-      name,
+-      publishedState,
+-      localVersion,
+-      publishedVersions
+-    } = pkgInfo;
++    const { name, publishedState, localVersion, publishedVersions } = pkgInfo;
+ 
+     if (!publishedVersions.includes(localVersion)) {
+       packagesToPublish.push(pkgInfo);
+-      info(`${name} is being published because our local version (${localVersion}) has not been published on npm`);
++      info(
++        `${name} is being published because our local version (${localVersion}) has not been published on npm`
++      );
+ 
+       if (preState !== undefined && publishedState === "only-pre") {
+-        info(`${name} is being published to ${chalk.cyan("latest")} rather than ${chalk.cyan(preState.tag)} because there has not been a regular release of it yet`);
++        info(
++          `${name} is being published to ${chalk.cyan(
++            "latest"
++          )} rather than ${chalk.cyan(
++            preState.tag
++          )} because there has not been a regular release of it yet`
++        );
+       }
+     } else {
+       // If the local version is behind npm, something is wrong, we warn here, and by not getting published later, it will fail
+-      warn(`${name} is not being published because version ${localVersion} is already published on npm`);
++      warn(
++        `${name} is not being published because version ${localVersion} is already published on npm`
++      );
+     }
+   }
+ 
+@@ -958,14 +1246,22 @@ async function getUnpublishedPackages(packages, preState) {
+ }
+ 
+ async function getUntaggedPrivatePackages(privatePackages, cwd, tool) {
+-  const packageWithTags = await Promise.all(privatePackages.map(async privatePkg => {
+-    const tagName = tool === "root" ? `v${privatePkg.packageJson.version}` : `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
+-    const isMissingTag = !((await git.tagExists(tagName, cwd)) || (await git.remoteTagExists(tagName)));
+-    return {
+-      pkg: privatePkg,
+-      isMissingTag
+-    };
+-  }));
++  const packageWithTags = await Promise.all(
++    privatePackages.map(async (privatePkg) => {
++      const tagName =
++        tool === "root"
++          ? `v${privatePkg.packageJson.version}`
++          : `${privatePkg.packageJson.name}@${privatePkg.packageJson.version}`;
++      const isMissingTag = !(
++        (await git.tagExists(tagName, cwd)) ||
++        (await git.remoteTagExists(tagName))
++      );
++      return {
++        pkg: privatePkg,
++        isMissingTag,
++      };
++    })
++  );
+   const untagged = [];
+ 
+   for (const packageWithTag of packageWithTags) {
+@@ -973,7 +1269,7 @@ async function getUntaggedPrivatePackages(privatePackages, cwd, tool) {
+       untagged.push({
+         name: packageWithTag.pkg.packageJson.name,
+         newVersion: packageWithTag.pkg.packageJson.version,
+-        published: false
++        published: false,
+       });
+     }
+   }
+@@ -982,19 +1278,27 @@ async function getUntaggedPrivatePackages(privatePackages, cwd, tool) {
+ }
+ 
+ function logReleases(pkgs) {
+-  const mappedPkgs = pkgs.map(p => `${p.name}@${p.newVersion}`).join("\n");
++  const mappedPkgs = pkgs.map((p) => `${p.name}@${p.newVersion}`).join("\n");
+   log(mappedPkgs);
+ }
+ 
+-let importantSeparator = chalk.red("===============================IMPORTANT!===============================");
+-let importantEnd = chalk.red("----------------------------------------------------------------------");
++let importantSeparator = chalk.red(
++  "===============================IMPORTANT!==============================="
++);
++let importantEnd = chalk.red(
++  "----------------------------------------------------------------------"
++);
+ 
+ function showNonLatestTagWarning(tag, preState) {
+   warn(importantSeparator);
+ 
+   if (preState) {
+-    warn(`You are in prerelease mode so packages will be published to the ${chalk.cyan(preState.tag)}
+-        dist tag except for packages that have not had normal releases which will be published to ${chalk.cyan("latest")}`);
++    warn(`You are in prerelease mode so packages will be published to the ${chalk.cyan(
++      preState.tag
++    )}
++        dist tag except for packages that have not had normal releases which will be published to ${chalk.cyan(
++          "latest"
++        )}`);
+   } else if (tag !== "latest") {
+     warn(`Packages will be released under the ${tag} tag`);
+   }
+@@ -1002,11 +1306,7 @@ function showNonLatestTagWarning(tag, preState) {
+   warn(importantEnd);
+ }
+ 
+-async function run$2(cwd, {
+-  otp,
+-  tag,
+-  gitTag = true
+-}, config) {
++async function run$2(cwd, { otp, tag, gitTag = true }, config) {
+   const releaseTag = tag && tag.length > 0 ? tag : undefined;
+   let preState = await readPreState(cwd);
+ 
+@@ -1020,28 +1320,35 @@ async function run$2(cwd, {
+     showNonLatestTagWarning(tag, preState);
+   }
+ 
+-  const {
+-    packages,
+-    tool
+-  } = await getPackages(cwd);
+-  const tagPrivatePackages = config.privatePackages && config.privatePackages.tag;
++  const { packages, tool } = await getPackages(cwd);
++  const tagPrivatePackages =
++    config.privatePackages && config.privatePackages.tag;
+   const publishedPackages = await publishPackages({
+     packages,
+     // if not public, we won't pass the access, and it works as normal
+     access: config.access,
+     otp,
+     preState,
+-    tag: releaseTag
++    tag: releaseTag,
+   });
+-  const privatePackages = packages.filter(pkg => pkg.packageJson.private && pkg.packageJson.version);
+-  const untaggedPrivatePackageReleases = tagPrivatePackages ? await getUntaggedPrivatePackages(privatePackages, cwd, tool) : [];
+-
+-  if (publishedPackages.length === 0 && untaggedPrivatePackageReleases.length === 0) {
++  const privatePackages = packages.filter(
++    (pkg) => pkg.packageJson.private && pkg.packageJson.version
++  );
++  const untaggedPrivatePackageReleases = tagPrivatePackages
++    ? await getUntaggedPrivatePackages(privatePackages, cwd, tool)
++    : [];
++
++  if (
++    publishedPackages.length === 0 &&
++    untaggedPrivatePackageReleases.length === 0
++  ) {
+     warn("No unpublished projects to publish");
+   }
+ 
+-  const successfulNpmPublishes = publishedPackages.filter(p => p.published);
+-  const unsuccessfulNpmPublishes = publishedPackages.filter(p => !p.published);
++  const successfulNpmPublishes = publishedPackages.filter((p) => p.published);
++  const unsuccessfulNpmPublishes = publishedPackages.filter(
++    (p) => !p.published
++  );
+ 
+   if (successfulNpmPublishes.length > 0) {
+     success("packages published successfully:");
+@@ -1083,37 +1390,39 @@ async function tagPublish(tool, packageReleases, cwd) {
+   }
+ }
+ 
+-async function getStatus(cwd, {
+-  sinceMaster,
+-  since,
+-  verbose,
+-  output
+-}, config) {
++async function getStatus(cwd, { sinceMaster, since, verbose, output }, config) {
+   if (sinceMaster) {
+-    warn("--sinceMaster is deprecated and will be removed in a future major version");
++    warn(
++      "--sinceMaster is deprecated and will be removed in a future major version"
++    );
+     warn("Use --since=master instead");
+   }
+ 
+-  const sinceBranch = since === undefined ? sinceMaster ? "master" : undefined : since;
++  const sinceBranch =
++    since === undefined ? (sinceMaster ? "master" : undefined) : since;
+   const releasePlan = await getReleasePlan(cwd, sinceBranch, config);
+-  const {
+-    changesets,
+-    releases
+-  } = releasePlan;
++  const { changesets, releases } = releasePlan;
+   const changedPackages = await git.getChangedPackagesSinceRef({
+     cwd,
+     ref: sinceBranch || config.baseBranch,
+-    changedFilePatterns: config.changedFilePatterns
++    changedFilePatterns: config.changedFilePatterns,
+   });
+ 
+   if (changedPackages.length > 0 && changesets.length === 0) {
+-    error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.");
+-    error("If this change doesn't need a release, run `changeset add --empty`.");
++    error(
++      "Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error."
++    );
++    error(
++      "If this change doesn't need a release, run `changeset add --empty`."
++    );
+     process.exit(1);
+   }
+ 
+   if (output) {
+-    await fs.writeFile(path.join(cwd, output), JSON.stringify(releasePlan, undefined, 2));
++    await fs.writeFile(
++      path.join(cwd, output),
++      JSON.stringify(releasePlan, undefined, 2)
++    );
+     return;
+   }
+ 
+@@ -1127,13 +1436,11 @@ async function getStatus(cwd, {
+ }
+ 
+ function SimplePrint(type, releases) {
+-  const packages = releases.filter(r => r.type === type);
++  const packages = releases.filter((r) => r.type === type);
+ 
+   if (packages.length) {
+     info(chalk`Packages to be bumped at {green ${type}}:\n`);
+-    const pkgs = packages.map(({
+-      name
+-    }) => `- ${name}`).join("\n");
++    const pkgs = packages.map(({ name }) => `- ${name}`).join("\n");
+     log(chalk.green(pkgs));
+   } else {
+     info(chalk`{red NO} packages to be bumped at {green ${type}}`);
+@@ -1141,33 +1448,45 @@ function SimplePrint(type, releases) {
+ }
+ 
+ function verbosePrint(type, releases) {
+-  const packages = releases.filter(r => r.type === type);
++  const packages = releases.filter((r) => r.type === type);
+ 
+   if (packages.length) {
+     info(chalk`Packages to be bumped at {green ${type}}`);
+-    const columns = packages.map(({
+-      name,
+-      newVersion: version,
+-      changesets
+-    }) => [chalk.green(name), version, changesets.map(c => chalk.blue(` .changeset/${c}.md`)).join(" +")]);
+-    const t1 = table([{
+-      value: "Package Name",
+-      width: 20
+-    }, {
+-      value: "New Version",
+-      width: 20
+-    }, {
+-      value: "Related Changeset Summaries",
+-      width: 70
+-    }], columns, {
+-      paddingLeft: 1,
+-      paddingRight: 0,
+-      headerAlign: "center",
+-      align: "left"
+-    });
++    const columns = packages.map(
++      ({ name, newVersion: version, changesets }) => [
++        chalk.green(name),
++        version,
++        changesets.map((c) => chalk.blue(` .changeset/${c}.md`)).join(" +"),
++      ]
++    );
++    const t1 = table(
++      [
++        {
++          value: "Package Name",
++          width: 20,
++        },
++        {
++          value: "New Version",
++          width: 20,
++        },
++        {
++          value: "Related Changeset Summaries",
++          width: 70,
++        },
++      ],
++      columns,
++      {
++        paddingLeft: 1,
++        paddingRight: 0,
++        headerAlign: "center",
++        align: "left",
++      }
++    );
+     log(t1.render() + "\n");
+   } else {
+-    info(chalk`Running release would release {red NO} packages as a {green ${type}}`);
++    info(
++      chalk`Running release would release {red NO} packages as a {green ${type}}`
++    );
+   }
+ }
+ 
+@@ -1176,11 +1495,15 @@ async function pre(cwd, options) {
+     try {
+       await enterPre(cwd, options.tag);
+       logger.success(`Entered pre mode with tag ${chalk.cyan(options.tag)}`);
+-      logger.info("Run `changeset version` to version packages with prerelease versions");
++      logger.info(
++        "Run `changeset version` to version packages with prerelease versions"
++      );
+     } catch (err) {
+       if (err instanceof PreEnterButInPreModeError) {
+         logger.error("`changeset pre enter` cannot be run when in pre mode");
+-        logger.info("If you're trying to exit pre mode, run `changeset pre exit`");
++        logger.info(
++          "If you're trying to exit pre mode, run `changeset pre exit`"
++        );
+         throw new ExitError(1);
+       }
+ 
+@@ -1190,11 +1513,15 @@ async function pre(cwd, options) {
+     try {
+       await exitPre(cwd);
+       logger.success(`Exited pre mode`);
+-      logger.info("Run `changeset version` to version packages with normal versions");
++      logger.info(
++        "Run `changeset version` to version packages with normal versions"
++      );
+     } catch (err) {
+       if (err instanceof PreExitButNotInPreModeError) {
+         logger.error("`changeset pre exit` can only be run when in pre mode");
+-        logger.info("If you're trying to enter pre mode, run `changeset pre enter`");
++        logger.info(
++          "If you're trying to enter pre mode, run `changeset pre enter`"
++        );
+         throw new ExitError(1);
+       }
+ 
+@@ -1204,14 +1531,14 @@ async function pre(cwd, options) {
+ }
+ 
+ async function run$1(cwd) {
+-  const {
+-    packages,
+-    tool
+-  } = await getPackages(cwd);
++  const { packages, tool } = await getPackages(cwd);
+   const allExistingTags = await git.getAllTags(cwd);
+ 
+   for (const pkg of packages) {
+-    const tag = tool !== "root" ? `${pkg.packageJson.name}@${pkg.packageJson.version}` : `v${pkg.packageJson.version}`;
++    const tag =
++      tool !== "root"
++        ? `${pkg.packageJson.name}@${pkg.packageJson.version}`
++        : `v${pkg.packageJson.version}`;
+ 
+     if (allExistingTags.has(tag)) {
+       log("Skipping tag (already exists): ", tag);
+@@ -1230,8 +1557,12 @@ async function run(input, flags, cwd) {
+ 
+   if (!fs.existsSync(path.resolve(cwd, ".changeset"))) {
+     error("There is no .changeset folder. ");
+-    error("If this is the first time `changesets` have been used in this project, run `yarn changeset init` to get set up.");
+-    error("If you expected there to be changesets, you should check git history for when the folder was removed to ensure you do not lose any configuration.");
++    error(
++      "If this is the first time `changesets` have been used in this project, run `yarn changeset init` to get set up."
++    );
++    error(
++      "If you expected there to be changesets, you should check git history for when the folder was removed to ensure you do not lose any configuration."
++    );
+     throw new ExitError(1);
+   }
+ 
+@@ -1241,13 +1572,21 @@ async function run(input, flags, cwd) {
+   try {
+     config = await read(cwd, packages);
+   } catch (e) {
+-    let oldConfigExists = await fs.pathExists(path.resolve(cwd, ".changeset/config.js"));
++    let oldConfigExists = await fs.pathExists(
++      path.resolve(cwd, ".changeset/config.js")
++    );
+ 
+     if (oldConfigExists) {
+-      error("It looks like you're using the version 1 `.changeset/config.js` file");
++      error(
++        "It looks like you're using the version 1 `.changeset/config.js` file"
++      );
+       error("You'll need to convert it to a `.changeset/config.json` file");
+-      error("The format of the config object has significantly changed in v2 as well");
+-      error(" - we thoroughly recommend looking at the changelog for this package for what has changed");
++      error(
++        "The format of the config object has significantly changed in v2 as well"
++      );
++      error(
++        " - we thoroughly recommend looking at the changelog for this package for what has changed"
++      );
+       throw new ExitError(1);
+     } else {
+       throw e;
+@@ -1255,17 +1594,20 @@ async function run(input, flags, cwd) {
+   }
+ 
+   if (input.length < 1) {
+-    const {
+-      empty,
+-      open
+-    } = flags; // @ts-ignore if this is undefined, we have already exited
++    const { empty, open } = flags; // @ts-ignore if this is undefined, we have already exited
+ 
+-    await add(cwd, {
+-      empty,
+-      open
+-    }, config);
++    await add(
++      cwd,
++      {
++        empty,
++        open,
++      },
++      config
++    );
+   } else if (input[0] !== "pre" && input.length > 1) {
+-    error("Too many arguments passed to changesets - we only accept the command name as an argument");
++    error(
++      "Too many arguments passed to changesets - we only accept the command name as an argument"
++    );
+   } else {
+     const {
+       sinceMaster,
+@@ -1279,12 +1621,14 @@ async function run(input, flags, cwd) {
+       snapshotPrereleaseTemplate,
+       tag,
+       open,
+-      gitTag
++      gitTag,
+     } = flags;
+     const deadFlags = ["updateChangelog", "isPublic", "skipCI", "commit"];
+-    deadFlags.forEach(flag => {
++    deadFlags.forEach((flag) => {
+       if (flags[flag]) {
+-        error(`the flag ${flag} has been removed from changesets for version 2`);
++        error(
++          `the flag ${flag} has been removed from changesets for version 2`
++        );
+         error(`Please encode the desired value into your config`);
+         error(`See our changelog for more details`);
+         throw new ExitError(1);
+@@ -1295,153 +1639,172 @@ async function run(input, flags, cwd) {
+     // object as and when they exist.
+ 
+     switch (input[0]) {
+-      case "add":
+-        {
+-          await add(cwd, {
++      case "add": {
++        await add(
++          cwd,
++          {
+             empty,
+-            open
+-          }, config);
+-          return;
+-        }
+-
+-      case "version":
+-        {
+-          let ignoreArrayFromCmd;
+-
+-          if (typeof ignore === "string") {
+-            ignoreArrayFromCmd = [ignore];
+-          } else {
+-            // undefined or an array
+-            ignoreArrayFromCmd = ignore;
+-          } // Validate that items in ignoreArrayFromCmd are valid project names
+-
+-
+-          let pkgNames = new Set(packages.packages.map(({
+-            packageJson
+-          }) => packageJson.name));
+-          const messages = [];
++            open,
++          },
++          config
++        );
++        return;
++      }
+ 
+-          for (const pkgName of ignoreArrayFromCmd || []) {
+-            if (!pkgNames.has(pkgName)) {
+-              messages.push(`The package "${pkgName}" is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`);
+-            }
++      case "version": {
++        let ignoreArrayFromCmd;
++
++        if (typeof ignore === "string") {
++          ignoreArrayFromCmd = [ignore];
++        } else {
++          // undefined or an array
++          ignoreArrayFromCmd = ignore;
++        } // Validate that items in ignoreArrayFromCmd are valid project names
++
++        let pkgNames = new Set(
++          packages.packages.map(({ packageJson }) => packageJson.name)
++        );
++        const messages = [];
++
++        for (const pkgName of ignoreArrayFromCmd || []) {
++          if (!pkgNames.has(pkgName)) {
++            messages.push(
++              `The package "${pkgName}" is passed to the \`--ignore\` option but it is not found in the project. You may have misspelled the package name.`
++            );
+           }
++        }
+ 
+-          if (config.ignore.length > 0 && ignoreArrayFromCmd) {
+-            messages.push(`It looks like you are trying to use the \`--ignore\` option while ignore is defined in the config file. This is currently not allowed, you can only use one of them at a time.`);
+-          } else if (ignoreArrayFromCmd) {
+-            // use the ignore flags from cli
+-            config.ignore = ignoreArrayFromCmd;
+-          } // Validate that all dependents of ignored packages are listed in the ignore list
+-
+-
+-          const dependentsGraph = getDependentsGraph(packages, {
+-            bumpVersionsWithWorkspaceProtocolOnly: config.bumpVersionsWithWorkspaceProtocolOnly
+-          });
++        if (config.ignore.length > 0 && ignoreArrayFromCmd) {
++          messages.push(
++            `It looks like you are trying to use the \`--ignore\` option while ignore is defined in the config file. This is currently not allowed, you can only use one of them at a time.`
++          );
++        } else if (ignoreArrayFromCmd) {
++          // use the ignore flags from cli
++          config.ignore = ignoreArrayFromCmd;
++        } // Validate that all dependents of ignored packages are listed in the ignore list
++
++        const dependentsGraph = getDependentsGraph(packages, {
++          bumpVersionsWithWorkspaceProtocolOnly:
++            config.bumpVersionsWithWorkspaceProtocolOnly,
++        });
+ 
+-          for (const ignoredPackage of config.ignore) {
+-            const dependents = dependentsGraph.get(ignoredPackage) || [];
++        for (const ignoredPackage of config.ignore) {
++          const dependents = dependentsGraph.get(ignoredPackage) || [];
+ 
+-            for (const dependent of dependents) {
+-              if (!config.ignore.includes(dependent)) {
+-                messages.push(`The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please pass "${dependent}" to the \`--ignore\` flag.`);
+-              }
++          for (const dependent of dependents) {
++            if (!config.ignore.includes(dependent)) {
++              messages.push(
++                `The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please pass "${dependent}" to the \`--ignore\` flag.`
++              );
+             }
+           }
++        }
+ 
+-          if (messages.length > 0) {
+-            error(messages.join("\n"));
+-            throw new ExitError(1);
+-          }
+-
+-          if (snapshotPrereleaseTemplate) {
+-            config.snapshot.prereleaseTemplate = snapshotPrereleaseTemplate;
+-          }
++        if (messages.length > 0) {
++          error(messages.join("\n"));
++          throw new ExitError(1);
++        }
+ 
+-          await version(cwd, {
+-            snapshot
+-          }, config);
+-          return;
++        if (snapshotPrereleaseTemplate) {
++          config.snapshot.prereleaseTemplate = snapshotPrereleaseTemplate;
+         }
+ 
+-      case "publish":
+-        {
+-          await run$2(cwd, {
++        await version(
++          cwd,
++          {
++            snapshot,
++          },
++          config
++        );
++        return;
++      }
++
++      case "publish": {
++        await run$2(
++          cwd,
++          {
+             otp,
+             tag,
+-            gitTag
+-          }, config);
+-          return;
+-        }
++            gitTag,
++          },
++          config
++        );
++        return;
++      }
+ 
+-      case "status":
+-        {
+-          await getStatus(cwd, {
++      case "status": {
++        await getStatus(
++          cwd,
++          {
+             sinceMaster,
+             since,
+             verbose,
+-            output
+-          }, config);
+-          return;
+-        }
++            output,
++          },
++          config
++        );
++        return;
++      }
+ 
+-      case "tag":
+-        {
+-          await run$1(cwd);
+-          return;
+-        }
++      case "tag": {
++        await run$1(cwd);
++        return;
++      }
+ 
+-      case "pre":
+-        {
+-          let command = input[1];
++      case "pre": {
++        let command = input[1];
+ 
+-          if (command !== "enter" && command !== "exit") {
+-            error("`enter`, `exit` or `snapshot` must be passed after prerelease");
+-            throw new ExitError(1);
+-          }
+-
+-          let tag = input[2];
++        if (command !== "enter" && command !== "exit") {
++          error(
++            "`enter`, `exit` or `snapshot` must be passed after prerelease"
++          );
++          throw new ExitError(1);
++        }
+ 
+-          if (command === "enter" && typeof tag !== "string") {
+-            error(`A tag must be passed when using prerelese enter`);
+-            throw new ExitError(1);
+-          } // @ts-ignore
++        let tag = input[2];
+ 
++        if (command === "enter" && typeof tag !== "string") {
++          error(`A tag must be passed when using prerelese enter`);
++          throw new ExitError(1);
++        } // @ts-ignore
+ 
+-          await pre(cwd, {
+-            command,
+-            tag
+-          });
+-          return;
+-        }
++        await pre(cwd, {
++          command,
++          tag,
++        });
++        return;
++      }
+ 
+-      case "bump":
+-        {
+-          error('In version 2 of changesets, "bump" has been renamed to "version" - see our changelog for an explanation');
+-          error("To fix this, use `changeset version` instead, and update any scripts that use changesets");
+-          throw new ExitError(1);
+-        }
++      case "bump": {
++        error(
++          'In version 2 of changesets, "bump" has been renamed to "version" - see our changelog for an explanation'
++        );
++        error(
++          "To fix this, use `changeset version` instead, and update any scripts that use changesets"
++        );
++        throw new ExitError(1);
++      }
+ 
+-      case "release":
+-        {
+-          error('In version 2 of changesets, "release" has been renamed to "publish" - see our changelog for an explanation');
+-          error("To fix this, use `changeset publish` instead, and update any scripts that use changesets");
+-          throw new ExitError(1);
+-        }
++      case "release": {
++        error(
++          'In version 2 of changesets, "release" has been renamed to "publish" - see our changelog for an explanation'
++        );
++        error(
++          "To fix this, use `changeset publish` instead, and update any scripts that use changesets"
++        );
++        throw new ExitError(1);
++      }
+ 
+-      default:
+-        {
+-          error(`Invalid command ${input[0]} was provided`);
+-          throw new ExitError(1);
+-        }
++      default: {
++        error(`Invalid command ${input[0]} was provided`);
++        throw new ExitError(1);
++      }
+     }
+   }
+ }
+ 
+-const {
+-  input,
+-  flags
+-} = meow(`
++const { input, flags } = meow(
++  `
+   Usage
+     $ changeset [command]
+   Commands
+@@ -1452,56 +1815,62 @@ const {
+     status [--since <branch>] [--verbose] [--output JSON_FILE.json]
+     pre <enter|exit> <tag>
+     tag
+-    `, {
+-  flags: {
+-    sinceMaster: {
+-      type: "boolean"
+-    },
+-    verbose: {
+-      type: "boolean",
+-      alias: "v"
++    `,
++  {
++    flags: {
++      sinceMaster: {
++        type: "boolean",
++      },
++      verbose: {
++        type: "boolean",
++        alias: "v",
++      },
++      output: {
++        type: "string",
++        alias: "o",
++      },
++      otp: {
++        type: "string",
++      },
++      empty: {
++        type: "boolean",
++      },
++      since: {
++        type: "string",
++      },
++      ignore: {
++        type: "string",
++        isMultiple: true,
++      },
++      tag: {
++        type: "string",
++      },
++      open: {
++        type: "boolean",
++      },
++      gitTag: {
++        type: "boolean",
++        default: true,
++      },
++      snapshotPrereleaseTemplate: {
++        type: "string",
++      }, // mixed type like this is not supported by `meow`
++      // if it gets passed explicitly then it's still available on the flags with an inferred type though
++      // snapshot: { type: "boolean" | "string" },
+     },
+-    output: {
+-      type: "string",
+-      alias: "o"
+-    },
+-    otp: {
+-      type: "string"
+-    },
+-    empty: {
+-      type: "boolean"
+-    },
+-    since: {
+-      type: "string"
+-    },
+-    ignore: {
+-      type: "string",
+-      isMultiple: true
+-    },
+-    tag: {
+-      type: "string"
+-    },
+-    open: {
+-      type: "boolean"
+-    },
+-    gitTag: {
+-      type: "boolean",
+-      default: true
+-    },
+-    snapshotPrereleaseTemplate: {
+-      type: "string"
+-    } // mixed type like this is not supported by `meow`
+-    // if it gets passed explicitly then it's still available on the flags with an inferred type though
+-    // snapshot: { type: "boolean" | "string" },
+-
+   }
+-});
++);
+ const cwd = process.cwd();
+-run(input, flags, cwd).catch(err => {
++run(input, flags, cwd).catch((err) => {
+   if (err instanceof InternalError) {
+-    error("The following error is an internal unexpected error, these should never happen.");
++    error(
++      "The following error is an internal unexpected error, these should never happen."
++    );
+     error("Please open an issue with the following link");
+-    error(`https://github.com/changesets/changesets/issues/new?title=${encodeURIComponent(`Unexpected error during ${input[0] || "add"} command`)}&body=${encodeURIComponent(`## Error
++    error(
++      `https://github.com/changesets/changesets/issues/new?title=${encodeURIComponent(
++        `Unexpected error during ${input[0] || "add"} command`
++      )}&body=${encodeURIComponent(`## Error
+ 
+ \`\`\`
+ ${format("", err).replace(process.cwd(), "<cwd>")}
+@@ -1509,14 +1878,17 @@ ${format("", err).replace(process.cwd(), "<cwd>")}
+ 
+ ## Versions
+ 
+-- @changesets/cli@${// eslint-disable-next-line import/no-extraneous-dependencies
+-    require("@changesets/cli/package.json").version}
++- @changesets/cli@${
++        // eslint-disable-next-line import/no-extraneous-dependencies
++        require("@changesets/cli/package.json").version
++      }
+ - node@${process.version}
+ 
+ ## Extra details
+ 
+ <!-- Add any extra details of what you were doing, ideas you have about what might have caused the error and reproduction steps if possible. If you have a repository we can look at that would be great. 😁 -->
+-`)}`);
++`)}`
++    );
+   }
+ 
+   if (err instanceof ExitError) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@changesets/changelog-git": "^0.2.0",
-    "@changesets/cli": "^2.27.1"
+    "@changesets/cli": "patch:@changesets/cli@npm%3A2.27.1#~/.yarn/patches/@changesets-cli-npm-2.27.1-2cfd25f1c6.patch"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,5 @@
   "packageManager": "yarn@4.1.0",
   "engines": {
     "node": ">=16.0.0"
-  },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true,
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,7 +2917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/cli@npm:^2.27.1":
+"@changesets/cli@npm:2.27.1":
   version: 2.27.1
   resolution: "@changesets/cli@npm:2.27.1"
   dependencies:
@@ -2956,6 +2956,48 @@ __metadata:
   bin:
     changeset: bin.js
   checksum: 10/b7729fae49af7e707d55751a702095f46e0b1143e28e0ca191651ec1ac61fe54dc2e3c11db8476293e71f538f24cc3eb968b1dbe77ce74d3776a90c3468c1c27
+  languageName: node
+  linkType: hard
+
+"@changesets/cli@patch:@changesets/cli@npm%3A2.27.1#~/.yarn/patches/@changesets-cli-npm-2.27.1-2cfd25f1c6.patch":
+  version: 2.27.1
+  resolution: "@changesets/cli@patch:@changesets/cli@npm%3A2.27.1#~/.yarn/patches/@changesets-cli-npm-2.27.1-2cfd25f1c6.patch::version=2.27.1&hash=7a2097"
+  dependencies:
+    "@babel/runtime": "npm:^7.20.1"
+    "@changesets/apply-release-plan": "npm:^7.0.0"
+    "@changesets/assemble-release-plan": "npm:^6.0.0"
+    "@changesets/changelog-git": "npm:^0.2.0"
+    "@changesets/config": "npm:^3.0.0"
+    "@changesets/errors": "npm:^0.2.0"
+    "@changesets/get-dependents-graph": "npm:^2.0.0"
+    "@changesets/get-release-plan": "npm:^4.0.0"
+    "@changesets/git": "npm:^3.0.0"
+    "@changesets/logger": "npm:^0.1.0"
+    "@changesets/pre": "npm:^2.0.0"
+    "@changesets/read": "npm:^0.6.0"
+    "@changesets/types": "npm:^6.0.0"
+    "@changesets/write": "npm:^0.3.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@types/semver": "npm:^7.5.0"
+    ansi-colors: "npm:^4.1.3"
+    chalk: "npm:^2.1.0"
+    ci-info: "npm:^3.7.0"
+    enquirer: "npm:^2.3.0"
+    external-editor: "npm:^3.1.0"
+    fs-extra: "npm:^7.0.1"
+    human-id: "npm:^1.0.2"
+    meow: "npm:^6.0.0"
+    outdent: "npm:^0.5.0"
+    p-limit: "npm:^2.2.0"
+    preferred-pm: "npm:^3.0.0"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.5.3"
+    spawndamnit: "npm:^2.0.0"
+    term-size: "npm:^2.1.0"
+    tty-table: "npm:^4.1.5"
+  bin:
+    changeset: bin.js
+  checksum: 10/51343c2f49d5d978f6de5c5083756105ef0d7487013d909c1dfba81114e6a9a1e56750b7aaa3f0013cdd4c539d4accc4cb52793f6444152917795df97df73ce9
   languageName: node
   linkType: hard
 
@@ -8369,7 +8411,7 @@ __metadata:
   resolution: "@xmtp/snap-monorepo@workspace:."
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
-    "@changesets/cli": "npm:^2.27.1"
+    "@changesets/cli": "patch:@changesets/cli@npm%3A2.27.1#~/.yarn/patches/@changesets-cli-npm-2.27.1-2cfd25f1c6.patch"
     "@metamask/eslint-config": "npm:^12.2.0"
     "@metamask/eslint-config-jest": "npm:^12.1.0"
     "@metamask/eslint-config-nodejs": "npm:^12.1.0"


### PR DESCRIPTION
the last attempt was unsuccessful, so here's another one.

- removed previous commit that added more config
- added patch to `@changesets/cli` to force the `--provenance` flag when publishing