### PR TITLE
Update version, snap manifest

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @xmtp/snap
 
-## 1.3.5
+## 1.3.6
 
 ### Patch Changes
 

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/snap",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Snap keystore implementation for XMTP",
   "repository": {
     "type": "git",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.4",
+  "version": "1.3.6",
   "description": "A Snap that securely stores your XMTP keys across apps",
   "proposedName": "Sign in with XMTP",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/xmtp/snap.git"
   },
   "source": {
-    "shasum": "a8Ea+n6V2EzDw+aH5+HtPclBye5K5pXwaFiHrUwhMSE=",
+    "shasum": "nSaMsID9TJhlwTnR/oAoNTYVm/2IBEDzPVJbaFVwpSI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
when publishing a new version of the NPM package, the snap manifest must also be updated. this can occur in the release PR as a manual step.

this PR manually increases the package version to `1.3.6` and updates the snap manifest to match. merging this PR should result in the publishing of `1.3.6`. `1.3.5` will be unpublished.